### PR TITLE
Mutual Aid Request Creation #134

### DIFF
--- a/contracts/geev-core/src/mutual_aid.rs
+++ b/contracts/geev-core/src/mutual_aid.rs
@@ -7,42 +7,42 @@ pub struct MutualAidContract;
 #[contractimpl]
 impl MutualAidContract {
     pub fn post_help_request(
-    env: Env,
-    creator: Address,
-    request_id: u64,
-    goal: i128,
-    token: Address,
-) -> u64 {
-    creator.require_auth();
+        env: Env,
+        creator: Address,
+        request_id: u64,
+        goal: i128,
+        token: Address,
+    ) -> u64 {
+        creator.require_auth();
 
-    if goal <= 0 {
-        panic_with_error!(&env, Error::InvalidGoalAmount);
+        if goal <= 0 {
+            panic_with_error!(&env, Error::InvalidGoalAmount);
+        }
+
+        // Prevent overwriting an existing request
+        let request_key = DataKey::HelpRequest(request_id);
+        if env.storage().persistent().has(&request_key) {
+            panic_with_error!(&env, Error::HelpRequestAlreadyExists);
+        }
+
+        let request = HelpRequest {
+            id: request_id,
+            creator: creator.clone(),
+            token,
+            goal,
+            raised_amount: 0, // ✅ bucket starts empty — no funds locked
+            status: HelpRequestStatus::Open,
+        };
+
+        env.storage().persistent().set(&request_key, &request);
+
+        env.events().publish(
+            (Symbol::new(&env, "HelpRequestPosted"), request_id, creator),
+            (goal,),
+        );
+
+        request_id
     }
-
-    // Prevent overwriting an existing request
-    let request_key = DataKey::HelpRequest(request_id);
-    if env.storage().persistent().has(&request_key) {
-        panic_with_error!(&env, Error::HelpRequestAlreadyExists);
-    }
-
-    let request = HelpRequest {
-         id: request_id,  
-        creator: creator.clone(),
-        token,
-        goal,
-        raised_amount: 0, // ✅ bucket starts empty — no funds locked
-        status: HelpRequestStatus::Open,
-    };
-
-    env.storage().persistent().set(&request_key, &request);
-
-    env.events().publish(
-        (Symbol::new(&env, "HelpRequestPosted"), request_id, creator),
-        (goal,),
-    );
-
-    request_id
-}
     pub fn donate(env: Env, donor: Address, request_id: u64, amount: i128) {
         donor.require_auth();
 

--- a/contracts/geev-core/src/types.rs
+++ b/contracts/geev-core/src/types.rs
@@ -18,8 +18,8 @@ pub enum Error {
     AlreadyInitialized = 12,
     ArithmeticOverflow = 13, // Added this to resolve the Clippy/Compile error
     NotAdmin = 14,
-InvalidGoalAmount = 15,
-HelpRequestAlreadyExists = 16,
+    InvalidGoalAmount = 15,
+    HelpRequestAlreadyExists = 16,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -77,5 +77,3 @@ pub enum DataKey {
     Admin,
     Fee,
 }
-
-


### PR DESCRIPTION
feat: implement post_help_request for Mutual Aid
Adds the ability for users to post a help request with a funding goal.

Opens an empty funding bucket (no funds locked upfront)
Validates goal amount and prevents duplicate request IDs
Emits HelpRequestPosted event on creation
Adds InvalidGoalAmount and HelpRequestAlreadyExists error variants

Closes #134 