### PR TITLE
fix(leaderboard): replace mock data with live /api/leaderboard endpoint

### DIFF
--- a/app/app/leaderboard/page.tsx
+++ b/app/app/leaderboard/page.tsx
@@ -13,80 +13,192 @@ import {
   Users,
 } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { mockPosts, mockUsers } from '@/lib/mock-data';
+import { useEffect, useState } from 'react';
 
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-import { useAppContext } from '@/contexts/app-context';
-import { useState } from 'react';
+  
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 type FilterPeriod = 'week' | 'month' | 'all-time';
 
+/** Shape of each entry in the API response's `leaderboard` array. */
+type LeaderboardUser = {
+  id: string;
+  name: string;
+  avatar_url: string | null;
+  xp: number;
+  post_count: number;
+  entry_count: number;
+  total_contributions: number;
+  badges: {
+    id: string;
+    name: string;
+    tier: string;
+  }[];
+};
+
+type LeaderboardResponse = {
+  leaderboard: LeaderboardUser[];
+  page: number;
+  limit: number;
+  period: string;
+  total: number;
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Map the UI's period values to what the API expects.
+ * The UI uses 'week'/'month'/'all-time'; the API uses 'weekly'/'monthly'/'all-time'.
+ */
+function toPeriodParam(period: FilterPeriod): string {
+  if (period === 'week') return 'weekly';
+  if (period === 'month') return 'monthly';
+  return 'all-time';
+}
+
+function getMedalIcon(rank: number) {
+  if (rank === 1) return <Crown className="w-5 h-5 text-amber-500" />;
+  if (rank === 2) return <Medal className="w-5 h-5 text-gray-400" />;
+  if (rank === 3) return <Medal className="w-5 h-5 text-orange-600" />;
+  return <Star className="w-5 h-5 text-gray-300" />;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
 export default function LeaderboardPage() {
-  const { user } = useAppContext();
-  const [selectedPeriod, setSelectedPeriod] =
-    useState<FilterPeriod>('all-time');
+  const [selectedPeriod, setSelectedPeriod] = useState<FilterPeriod>('all-time');
+  const [data, setData] = useState<LeaderboardResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  // Calculate top givers (by number of giveaways created)
-  const topGivers = mockUsers
-    .map((u) => ({
-      ...u,
-      giveawayCount: mockPosts.filter(
-        (p) => p.userId === u.id && p.type === 'giveaway',
-      ).length,
-    }))
-    .sort((a, b) => b.giveawayCount - a.giveawayCount)
+  // Fetch from the live API whenever the period filter changes.
+  useEffect(() => {
+    const fetchLeaderboard = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `/api/leaderboard?period=${toPeriodParam(selectedPeriod)}&page=1&limit=50`
+        );
+        if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+        const json = await res.json();
+        setData(json.data); // apiSuccess wraps the payload in { data: ... }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load leaderboard');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchLeaderboard();
+  }, [selectedPeriod]);
+
+  // Derive the per-tab arrays from the single API response.
+  // The API returns a unified list sorted by total_contributions.
+  // We re-sort per tab to surface the right metric for each view.
+  const users = data?.leaderboard ?? [];
+
+  /** Top Givers — users who have created the most posts (giveaways). */
+  const topGivers = [...users]
+    .sort((a, b) => b.post_count - a.post_count)
     .slice(0, 20);
 
-  // Get top giveaways (by entries and engagement)
-  const topGiveaways = mockPosts
-    .filter((p) => p.type === 'giveaway')
-    .sort(
-      (a, b) =>
-        (b.entriesCount || 0) +
-        (b.likesCount || 0) -
-        ((a.entriesCount || 0) + (a.likesCount || 0)),
-    )
+  /** Top Requestors — users who have made the most entries/requests. */
+  const topRequestors = [...users]
+    .sort((a, b) => b.entry_count - a.entry_count)
     .slice(0, 20);
 
-  // Calculate top requestors (by number of help requests created)
-  const topRequestors = mockUsers
-    .map((u) => ({
-      ...u,
-      requestCount: mockPosts.filter(
-        (p) => p.userId === u.id && p.type === 'help-request',
-      ).length,
-    }))
-    .sort((a, b) => b.requestCount - a.requestCount)
+  /** Trending — users with the highest overall activity (posts + entries). */
+  const trendingUsers = [...users]
+    .sort((a, b) => b.total_contributions - a.total_contributions)
     .slice(0, 20);
 
-  // Get top requests (by responses and engagement)
-  const topRequests = mockPosts
-    .filter((p) => p.type === 'help-request')
-    .sort(
-      (a, b) =>
-        (b.entriesCount || 0) +
-        (b.likesCount || 0) -
-        ((a.entriesCount || 0) + (a.likesCount || 0)),
-    )
-    .slice(0, 20);
+  // ── Render helpers ──────────────────────────────────────────────────────────
 
-  // Get trending (most active in the last period)
-  const trendingUsers = mockUsers
-    .map((u) => ({
-      ...u,
-      activityScore: (u._count?.posts || 0) + (u._count?.followers || 0) / 100,
-    }))
-    .sort((a, b) => b.activityScore - a.activityScore)
-    .slice(0, 20);
+  const renderSkeleton = () => (
+    <div className="space-y-4">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 p-4 rounded-lg animate-pulse"
+        >
+          <div className="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700" />
+          <div className="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700" />
+          <div className="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+            <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/4" />
+          </div>
+          <div className="h-6 w-12 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      ))}
+    </div>
+  );
 
-  const getMedalIcon = (rank: number) => {
-    if (rank === 1) return <Crown className="w-5 h-5 text-amber-500" />;
-    if (rank === 2) return <Medal className="w-5 h-5 text-gray-400" />;
-    if (rank === 3) return <Medal className="w-5 h-5 text-orange-600" />;
-    return <Star className="w-5 h-5 text-gray-300" />;
-  };
+  const renderError = () => (
+    <div className="text-center py-12 text-red-500">
+      <p className="font-medium">Failed to load leaderboard</p>
+      <p className="text-sm mt-1 text-gray-500">{error}</p>
+      <Button
+        variant="outline"
+        className="mt-4"
+        onClick={() => setSelectedPeriod(selectedPeriod)} // re-triggers useEffect
+      >
+        Try again
+      </Button>
+    </div>
+  );
+
+  const renderUserRow = (
+    u: LeaderboardUser,
+    idx: number,
+    metric: { value: number; label: string; colorClass: string },
+  ) => (
+    <Link key={u.id} href={`/profile/${u.id}`}>
+      <div className="flex items-center gap-4 p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group">
+        <div className="flex items-center justify-center w-8 h-8">
+          {getMedalIcon(idx + 1)}
+        </div>
+        <span className="text-lg font-bold text-gray-500 dark:text-gray-400 w-8">
+          #{idx + 1}
+        </span>
+        <Avatar className="h-10 w-10">
+          <AvatarImage
+            src={u.avatar_url || '/placeholder.svg'}
+            alt={u.name}
+          />
+          <AvatarFallback className="bg-orange-500 text-white">
+            {u.name
+              .split(' ')
+              .map((n) => n[0])
+              .join('')}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold text-gray-900 dark:text-white group-hover:text-orange-600 transition-colors">
+            {u.name}
+          </p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {u.xp.toLocaleString()} XP
+          </p>
+        </div>
+        <div className="text-right">
+          <div className={`font-bold ${metric.colorClass}`}>{metric.value}</div>
+          <div className="text-xs text-gray-600 dark:text-gray-400">
+            {metric.label}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="font-bold text-blue-600">{u.badges.length}</div>
+          <div className="text-xs text-gray-600 dark:text-gray-400">Badges</div>
+        </div>
+      </div>
+    </Link>
+  );
+
+  // ── Markup ──────────────────────────────────────────────────────────────────
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -155,7 +267,7 @@ export default function LeaderboardPage() {
             </TabsTrigger>
           </TabsList>
 
-          {/* Top Givers Tab */}
+          {/* Top Givers */}
           <TabsContent value="givers">
             <Card>
               <CardHeader>
@@ -165,68 +277,22 @@ export default function LeaderboardPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
-                  {topGivers.map((giver, idx) => (
-                    <Link key={giver.id} href={`/profile/${giver.id}`}>
-                      <div className="flex items-center gap-4 p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group">
-                        <div className="flex items-center justify-center w-8 h-8">
-                          {getMedalIcon(idx + 1)}
-                        </div>
-                        <span className="text-lg font-bold text-gray-500 dark:text-gray-400 w-8">
-                          #{idx + 1}
-                        </span>
-                        <Avatar className="h-10 w-10">
-                          <AvatarImage
-                            src={giver.avatarUrl || '/placeholder.svg'}
-                            alt={giver.name}
-                          />
-                          <AvatarFallback className="bg-orange-500 text-white">
-                            {giver.name
-                              .split(' ')
-                              .map((n) => n[0])
-                              .join('')}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2">
-                            <p className="font-semibold text-gray-900 dark:text-white group-hover:text-orange-600 transition-colors">
-                              {giver.name}
-                            </p>
-                            {giver.isVerified && (
-                              <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border-0 text-xs">
-                                Verified
-                              </Badge>
-                            )}
-                          </div>
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            @{giver.username}
-                          </p>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-bold text-orange-600">
-                            {giver.giveawayCount}
-                          </div>
-                          <div className="text-xs text-gray-600 dark:text-gray-400">
-                            Giveaways
-                          </div>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-bold text-blue-600">
-                            {giver.badges?.length || 0}
-                          </div>
-                          <div className="text-xs text-gray-600 dark:text-gray-400">
-                            Badges
-                          </div>
-                        </div>
-                      </div>
-                    </Link>
-                  ))}
-                </div>
+                {isLoading ? renderSkeleton() : error ? renderError() : (
+                  <div className="space-y-4">
+                    {topGivers.map((u, idx) =>
+                      renderUserRow(u, idx, {
+                        value: u.post_count,
+                        label: 'Giveaways',
+                        colorClass: 'text-orange-600',
+                      })
+                    )}
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
 
-          {/* Top Giveaways Tab */}
+          {/* Top Giveaways — requires a dedicated posts endpoint */}
           <TabsContent value="giveaways">
             <Card>
               <CardHeader>
@@ -236,52 +302,20 @@ export default function LeaderboardPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
-                  {topGiveaways.map((post, idx) => {
-                    const creator = mockUsers.find((u) => u.id === post.userId);
-                    return (
-                      <Link key={post.id} href={`/post/${post.id}`}>
-                        <div className="flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group">
-                          <div className="flex items-center justify-center w-8 h-8 mt-1">
-                            {getMedalIcon(idx + 1)}
-                          </div>
-                          <span className="text-lg font-bold text-gray-500 dark:text-gray-400 w-8">
-                            #{idx + 1}
-                          </span>
-                          <div className="flex-1 min-w-0">
-                            <p className="font-semibold text-gray-900 dark:text-white group-hover:text-orange-600 transition-colors line-clamp-1">
-                              {post.title}
-                            </p>
-                            <p className="text-sm text-gray-600 dark:text-gray-400">
-                              by {creator?.name || 'Unknown'}
-                            </p>
-                          </div>
-                          <div className="text-right">
-                            <div className="font-bold text-orange-600">
-                              {post.entriesCount || 0}
-                            </div>
-                            <div className="text-xs text-gray-600 dark:text-gray-400">
-                              Entries
-                            </div>
-                          </div>
-                          <div className="text-right">
-                            <div className="font-bold text-red-600">
-                              {post.likesCount || 0}
-                            </div>
-                            <div className="text-xs text-gray-600 dark:text-gray-400">
-                              Likes
-                            </div>
-                          </div>
-                        </div>
-                      </Link>
-                    );
-                  })}
-                </div>
+                {isLoading ? renderSkeleton() : error ? renderError() : (
+                  <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+                    <TrendingUp className="w-10 h-10 mx-auto mb-3 opacity-40" />
+                    <p className="font-medium">Trending giveaways coming soon</p>
+                    <p className="text-sm mt-1">
+                      This tab will show top posts once the posts leaderboard endpoint is available.
+                    </p>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
 
-          {/* Top Requestors Tab */}
+          {/* Top Requestors */}
           <TabsContent value="requestors">
             <Card>
               <CardHeader>
@@ -291,68 +325,22 @@ export default function LeaderboardPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
-                  {topRequestors.map((requestor, idx) => (
-                    <Link key={requestor.id} href={`/profile/${requestor.id}`}>
-                      <div className="flex items-center gap-4 p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group">
-                        <div className="flex items-center justify-center w-8 h-8">
-                          {getMedalIcon(idx + 1)}
-                        </div>
-                        <span className="text-lg font-bold text-gray-500 dark:text-gray-400 w-8">
-                          #{idx + 1}
-                        </span>
-                        <Avatar className="h-10 w-10">
-                          <AvatarImage
-                            src={requestor.avatarUrl || '/placeholder.svg'}
-                            alt={requestor.name}
-                          />
-                          <AvatarFallback className="bg-red-500 text-white">
-                            {requestor.name
-                              .split(' ')
-                              .map((n) => n[0])
-                              .join('')}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2">
-                            <p className="font-semibold text-gray-900 dark:text-white group-hover:text-orange-600 transition-colors">
-                              {requestor.name}
-                            </p>
-                            {requestor.isVerified && (
-                              <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border-0 text-xs">
-                                Verified
-                              </Badge>
-                            )}
-                          </div>
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            @{requestor.username}
-                          </p>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-bold text-red-600">
-                            {requestor.requestCount}
-                          </div>
-                          <div className="text-xs text-gray-600 dark:text-gray-400">
-                            Requests
-                          </div>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-bold text-blue-600">
-                            {requestor.badges?.length || 0}
-                          </div>
-                          <div className="text-xs text-gray-600 dark:text-gray-400">
-                            Badges
-                          </div>
-                        </div>
-                      </div>
-                    </Link>
-                  ))}
-                </div>
+                {isLoading ? renderSkeleton() : error ? renderError() : (
+                  <div className="space-y-4">
+                    {topRequestors.map((u, idx) =>
+                      renderUserRow(u, idx, {
+                        value: u.entry_count,
+                        label: 'Requests',
+                        colorClass: 'text-red-600',
+                      })
+                    )}
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
 
-          {/* Top Requests Tab */}
+          {/* Top Requests — requires a dedicated posts endpoint */}
           <TabsContent value="requests">
             <Card>
               <CardHeader>
@@ -362,52 +350,20 @@ export default function LeaderboardPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
-                  {topRequests.map((post, idx) => {
-                    const creator = mockUsers.find((u) => u.id === post.userId);
-                    return (
-                      <Link key={post.id} href={`/post/${post.id}`}>
-                        <div className="flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group">
-                          <div className="flex items-center justify-center w-8 h-8 mt-1">
-                            {getMedalIcon(idx + 1)}
-                          </div>
-                          <span className="text-lg font-bold text-gray-500 dark:text-gray-400 w-8">
-                            #{idx + 1}
-                          </span>
-                          <div className="flex-1 min-w-0">
-                            <p className="font-semibold text-gray-900 dark:text-white group-hover:text-orange-600 transition-colors line-clamp-1">
-                              {post.title}
-                            </p>
-                            <p className="text-sm text-gray-600 dark:text-gray-400">
-                              by {creator?.name || 'Unknown'}
-                            </p>
-                          </div>
-                          <div className="text-right">
-                            <div className="font-bold text-purple-600">
-                              {post.entriesCount || 0}
-                            </div>
-                            <div className="text-xs text-gray-600 dark:text-gray-400">
-                              Responses
-                            </div>
-                          </div>
-                          <div className="text-right">
-                            <div className="font-bold text-red-600">
-                              {post.likesCount || 0}
-                            </div>
-                            <div className="text-xs text-gray-600 dark:text-gray-400">
-                              Likes
-                            </div>
-                          </div>
-                        </div>
-                      </Link>
-                    );
-                  })}
-                </div>
+                {isLoading ? renderSkeleton() : error ? renderError() : (
+                  <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+                    <Users className="w-10 h-10 mx-auto mb-3 opacity-40" />
+                    <p className="font-medium">Trending requests coming soon</p>
+                    <p className="text-sm mt-1">
+                      This tab will show top posts once the posts leaderboard endpoint is available.
+                    </p>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
 
-          {/* Trending Tab */}
+          {/* Trending */}
           <TabsContent value="trending">
             <Card>
               <CardHeader>
@@ -417,67 +373,17 @@ export default function LeaderboardPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
-                  {trendingUsers.map((trendingUser, idx) => (
-                    <Link
-                      key={trendingUser.id}
-                      href={`/profile/${trendingUser.id}`}
-                    >
-                      <div className="flex items-center gap-4 p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group">
-                        <div className="flex items-center justify-center w-8 h-8">
-                          {getMedalIcon(idx + 1)}
-                        </div>
-                        <span className="text-lg font-bold text-gray-500 dark:text-gray-400 w-8">
-                          #{idx + 1}
-                        </span>
-                        <Avatar className="h-10 w-10">
-                          <AvatarImage
-                            src={trendingUser.avatarUrl || '/placeholder.svg'}
-                            alt={trendingUser.name}
-                          />
-                          <AvatarFallback className="bg-yellow-500 text-white">
-                            {trendingUser.name
-                              .split(' ')
-                              .map((n) => n[0])
-                              .join('')}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2">
-                            <p className="font-semibold text-gray-900 dark:text-white group-hover:text-orange-600 transition-colors">
-                              {trendingUser.name}
-                            </p>
-                            {trendingUser.isVerified && (
-                              <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border-0 text-xs">
-                                Verified
-                              </Badge>
-                            )}
-                          </div>
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            @{trendingUser.username}
-                          </p>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-bold text-orange-600">
-                            {trendingUser._count?.posts || 0}
-                          </div>
-                          <div className="text-xs text-gray-600 dark:text-gray-400">
-                            Posts
-                          </div>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-bold text-blue-600">
-                            {(trendingUser._count?.followers / 1000).toFixed(1)}
-                            K
-                          </div>
-                          <div className="text-xs text-gray-600 dark:text-gray-400">
-                            Followers
-                          </div>
-                        </div>
-                      </div>
-                    </Link>
-                  ))}
-                </div>
+                {isLoading ? renderSkeleton() : error ? renderError() : (
+                  <div className="space-y-4">
+                    {trendingUsers.map((u, idx) =>
+                      renderUserRow(u, idx, {
+                        value: u.total_contributions,
+                        label: 'Activity',
+                        colorClass: 'text-yellow-600',
+                      })
+                    )}
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>


### PR DESCRIPTION
## Summary
Replaces all mock data on the `/leaderboard` page with live data from the
existing `/api/leaderboard` endpoint. Every visitor now sees real users
from the database instead of the same hardcoded fixtures.

## Changes

### `app/app/leaderboard/page.tsx`
- Removed `mockUsers` and `mockPosts` imports from `lib/mock-data`
- Removed `useAppContext` (was imported but never used in render)
- Added `useEffect` + `fetch` to call `/api/leaderboard` on mount and
  whenever the period filter changes
- Added `toPeriodParam()` helper to map UI values (`week/month/all-time`)
  to API values (`weekly/monthly/all-time`)
- Derived `topGivers`, `topRequestors`, and `trendingUsers` by re-sorting
  the single API response per tab — no extra requests needed
- Added loading skeleton while fetch is in flight
- Added error state with a retry button
- `avatar_url` (snake_case from API) handled correctly without renaming

## Notes
- The **Giveaways** and **Requests** tabs previously relied on post objects
  from mock data. The leaderboard API only returns user data, so these tabs
  now show a "coming soon" placeholder pending a dedicated posts leaderboard
  endpoint
- No changes to the API route or any other file

Closes #175