### PR TITLE
fix: replace mock data with real API calls across feed, post, profile…

### DIFF
--- a/app/app/activity/page.tsx
+++ b/app/app/activity/page.tsx
@@ -17,43 +17,42 @@ import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
 import { UserRankBadge } from '@/components/user-rank-badge';
 import { useAppContext } from '@/contexts/app-context';
+import { useEffect,  useState } from 'react';
 
 export default function ActivityPage() {
-  const { posts, entries, contributions, user } = useAppContext();
+  const { user } = useAppContext();
+  const [activity, setActivity] = useState<any>(null);
+  const [userPosts, setUserPosts] = useState<any[]>([]);
+  const [userEntries, setUserEntries] = useState<any[]>([]);
+  const [userContributions, setUserContributions] = useState<any[]>([]);
+  const [recentActivities, setRecentActivities] = useState<any[]>([]);
 
-  // Get user's activities
-  const userPosts = posts.filter((post) => post.userId === user?.id);
-  const userEntries = entries.filter((entry) => entry.userId === user?.id);
-  const userContributions = contributions.filter(
-    (contribution) => contribution.userId === user?.id,
-  );
+  useEffect(() => {
+    if (!user?.id) return;
 
-  // Get recent activities from all users
-  const recentActivities = [
-    ...posts.map((post) => ({
-      id: `post-${post.id}`,
-      type: 'post' as const,
-      user: post.author,
-      post,
-      timestamp: post.createdAt,
-    })),
-    ...entries.map((entry) => ({
-      id: `entry-${entry.id}`,
-      type: 'entry' as const,
-      user: entry.user,
-      entry,
-      post: posts.find((p) => p.id === entry.postId),
-      timestamp: entry.submittedAt,
-    })),
-    ...contributions.map((contribution) => ({
-      id: `contribution-${contribution.id}`,
-      type: 'contribution' as const,
-      user: contribution.user,
-      contribution,
-      post: posts.find((p) => p.id === contribution.postId),
-      timestamp: contribution.contributedAt,
-    })),
-  ].sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+    const loadActivity = async () => {
+      try{
+        const [activityRes, postsRes] = await Promise.all([
+          fetch(`/api/users/${user.id}/activity`),
+          fetch(`/api/posts`),
+        ]);
+
+        if (activityRes.ok) {
+          const activityData = await activityRes.json();
+          const data = activityData.data ?? {};
+          setUserPosts(data.posts ?? []);
+          setUserEntries(data.entries ?? []);
+          setUserContributions(data.contributions ?? []);
+          setRecentActivities(data.recentActivities ?? []);
+        }
+      } catch (error) {
+        console.error('Failed to load activity:', error);
+    }
+    };
+    loadActivity();
+  }, [user?.id]);
+
+
 
   const ActivityItem = ({
     activity,
@@ -253,7 +252,7 @@ export default function ActivityPage() {
               <CardContent className="space-y-4">
                 {userEntries.length > 0 ? (
                   userEntries.map((entry) => {
-                    const post = posts.find((p) => p.id === entry.postId);
+                    const post = entry.post;
                     return (
                       <Card
                         key={entry.id}
@@ -304,9 +303,7 @@ export default function ActivityPage() {
               <CardContent className="space-y-4">
                 {userContributions.length > 0 ? (
                   userContributions.map((contribution) => {
-                    const post = posts.find(
-                      (p) => p.id === contribution.postId,
-                    );
+                    const post = contribution.post;
                     return (
                       <Card
                         key={contribution.id}

--- a/app/app/post/[postId]/page.tsx
+++ b/app/app/post/[postId]/page.tsx
@@ -28,10 +28,11 @@ import Link from "next/link";
 import { Progress } from "@/components/ui/progress";
 import { UserRankBadge } from "@/components/user-rank-badge";
 import { useAppContext } from "@/contexts/app-context";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function PostPage() {
-  const { posts, user, burnPost } = useAppContext();
+  const { user, burnPost } = useAppContext();
+  const [post, setPost] = useState<any>(null);
   const params = useParams();
   const postId = params.postId as string;
   const [isBurned, setIsBurned] = useState(false);
@@ -43,8 +44,22 @@ export default function PostPage() {
   const [showContributionForm, setShowContributionForm] = useState(false);
 
   const router = useRouter();
-  const post = posts.find((p) => p.id === postId);
   const canInteract = user && user.id !== post?.userId;
+
+  useEffect(() => {
+    const loadPost = async () => {
+      try {
+        const res = await fetch(`/api/posts/${postId}`);
+        if(res.ok) {
+          const data = await res.json();
+          setPost(data.data);
+        }
+      } catch (error) {
+        console.error('Failed to load post: ', error);
+      }
+    };
+    if (postId) loadPost();
+  }, [postId]);
 
   if (!post) {
     return (

--- a/app/app/profile/[userId]/page.tsx
+++ b/app/app/profile/[userId]/page.tsx
@@ -13,20 +13,54 @@ import { PostCard } from '@/components/post-card';
 import { UserRankBadge } from '@/components/user-rank-badge';
 import { useAppContext } from '@/contexts/app-context';
 import { useParams } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function ProfilePage() {
   const params = useParams();
-  const { users, posts, user: currentUser } = useAppContext();
+  const { user: currentUser } = useAppContext();
+  const [profileUser, setProfileUser] = useState<any>(null);
+  const [userPosts, setUserPosts] = useState<any[]>([]);
   const [showAchievements, setShowAchievements] = useState(false);
 
   const userId = params.userId as string;
-  const profileUser = users.find((u) => u.id === userId);
-  const userPosts = posts.filter((p) => p.userId === userId);
+  //const profileUser = users.find((u) => u.id === userId);
+  //const userPosts = posts.filter((p) => p.userId === userId);
   const isOwnProfile = currentUser?.id === userId;
 
   const givePosts = userPosts.filter((p) => p.type === 'giveaway').length;
   const takePosts = userPosts.filter((p) => p.type === 'help-request').length;
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      try {
+        const [userRes, postsRes] = await Promise.all([
+          fetch(`/api/users/${userId}`),
+          fetch(`/api/posts?userId=${userId}`),
+        ]);
+
+        if (userRes.ok) {
+          const userData = await userRes.json();
+          setProfileUser(userData.data);
+        }
+
+        if (postsRes.ok) {
+          const postsData = await postsRes.json(); 
+          setUserPosts(postsData.data ?? []);
+        }
+      } catch (error) {
+        console.error('Failed to load profile:', error);
+      }
+    };
+
+    if (userId) loadProfile();
+  }, [userId]);
+
+
+
+
+
+
+
 
   if (!profileUser) {
     return (

--- a/app/contexts/app-context.tsx
+++ b/app/contexts/app-context.tsx
@@ -18,7 +18,6 @@ import {
   useState,
 } from 'react';
 import { deserializeState, serializeState } from '@/lib/utils';
-import { mockPosts, mockUsers } from '@/lib/mock-data';
 import { signIn, signOut } from 'next-auth/react';
 
 import type React from 'react';
@@ -229,10 +228,6 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       console.error('Failed to load state from localStorage:', error);
     }
 
-    // Load mock data
-    dispatch({ type: 'SET_USERS', payload: mockUsers });
-    dispatch({ type: 'SET_POSTS', payload: mockPosts });
-
     setIsHydrated(true);
   }, []);
 
@@ -249,9 +244,30 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     return () => clearTimeout(timeoutId);
   }, [state, isHydrated]);
 
+  // Load real data from API
   useEffect(() => {
-    dispatch({ type: 'SET_USERS', payload: mockUsers });
-    dispatch({ type: 'SET_POSTS', payload: mockPosts });
+    const loadData = async () => {
+      try{
+        const [postRes, userRes] = await Promise.all([
+          fetch('/api/posts'),
+          fetch('/api/users'),
+        ]);
+
+        if (postRes.ok) {
+          const postData = await postRes.json();
+          dispatch({ type: 'SET_POSTS', payload: Array.isArray(postData.data) ? postData.data : postData.data?.posts ?? [] });
+        }
+
+        if (userRes.ok) {
+          const userData = await userRes.json();
+          dispatch({ type: 'SET_USERS', payload: userData.data ?? [] });
+        }
+
+      } catch (error) {
+        console.error('Failed to load data from API', error);
+      }
+    };
+    loadData();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Description
This PR fixes the issue where the Feed, Post Detail, Profile, and Activity pages were populated from in-memory mock state instead of real database content.
Changes Made

app/contexts/app-context.tsx: Removed the two duplicate useEffect blocks that dispatched mockUsers and mockPosts. Replaced with real API calls to GET /api/posts and GET /api/users.
app/app/post/[postId]/page.tsx: Replaced posts.find() from context with a direct GET /api/posts/[id] call.
app/app/profile/[userId]/page.tsx: Replaced users.find() and posts.filter() from context with GET /api/users/[id] and GET /api/posts?userId=[id] calls.
app/app/activity/page.tsx: Replaced context-based mock data with GET /api/users/[id]/activity call.

Testing
Tested locally with a real PostgreSQL database (Supabase). Feed, Profile, Post Detail and Activity pages now show real data instead of mock data.
Closes #177