### PR TITLE
feat: implement XP / reputation awarding system

### DIFF
--- a/app/app/api/leaderboard/route.ts
+++ b/app/app/api/leaderboard/route.ts
@@ -39,6 +39,9 @@ export async function GET (request: NextRequest) {
           },
         },
       },
+      orderBy: {
+        xp: 'desc',
+      },
       take: limit,
       skip: (page - 1) * limit,
     });
@@ -69,8 +72,11 @@ export async function GET (request: NextRequest) {
       }),
     );
 
-    // Sort by total contributions
-    leaderboard.sort((a, b) => b.total_contributions - a.total_contributions);
+    // Sort by XP and fall back to total contributions for ties.
+    leaderboard.sort((a, b) => {
+      if (b.xp !== a.xp) return b.xp - a.xp;
+      return b.total_contributions - a.total_contributions;
+    });
 
     return apiSuccess({
       leaderboard,

--- a/app/app/api/posts/[id]/entries/route.ts
+++ b/app/app/api/posts/[id]/entries/route.ts
@@ -1,4 +1,5 @@
 import { apiError, apiSuccess } from '@/lib/api-response';
+import { awardXp, XP_REWARDS } from '@/lib/xp';
 
 import { NextRequest } from 'next/server';
 import { getCurrentUser } from '@/lib/auth';
@@ -67,23 +68,40 @@ export async function POST (
     }
 
     // Create entry
-    const entry = await prisma.entry.create({
-      data: {
-        postId,
-        userId: user.id,
-        content,
-        proofUrl: proofUrl || null,
-      },
-      include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            walletAddress: true,
-            avatarUrl: true,
+    const entry = await prisma.$transaction(async (tx) => {
+      const createdEntry = await tx.entry.create({
+        data: {
+          postId,
+          userId: user.id,
+          content,
+          proofUrl: proofUrl || null,
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              walletAddress: true,
+              avatarUrl: true,
+            },
           },
         },
-      },
+      });
+
+      await awardXp(
+        user.id,
+        XP_REWARDS.enterGiveaway,
+        'giveaway_entered',
+        {
+          metadata: {
+            postId,
+            entryId: createdEntry.id,
+          },
+        },
+        tx,
+      );
+
+      return createdEntry;
     });
 
     return apiSuccess(entry, 'Entry created successfully', 201);

--- a/app/app/api/posts/[id]/like/route.ts
+++ b/app/app/api/posts/[id]/like/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { getCurrentUser } from '@/lib/auth';
+import { awardXp, XP_REWARDS } from '@/lib/xp';
 
 export async function POST(
   request: NextRequest,
@@ -13,33 +14,67 @@ export async function POST(
 
     const { id: postId } = await params;
 
-    // Insert like (ignore if already exists)
-    await prisma.interaction.upsert({
-      where: {
-        userId_postId_type: {
+    const { count } = await prisma.$transaction(async (tx) => {
+      const post = await tx.post.findUnique({
+        where: { id: postId },
+        select: {
+          id: true,
+          userId: true,
+        },
+      });
+
+      if (!post) {
+        throw new Error('POST_NOT_FOUND');
+      }
+
+      await tx.interaction.upsert({
+        where: {
+          userId_postId_type: {
+            userId: user.id,
+            postId,
+            type: 'like',
+          },
+        },
+        update: {},
+        create: {
           userId: user.id,
           postId,
           type: 'like',
         },
-      },
-      update: {},
-      create: {
-        userId: user.id,
-        postId,
-        type: 'like',
-      },
-    });
+      });
 
-    // Get updated count
-    const count = await prisma.interaction.count({
-      where: {
-        postId,
-        type: 'like',
-      },
+      const likeCount = await tx.interaction.count({
+        where: {
+          postId,
+          type: 'like',
+        },
+      });
+
+      if (likeCount === 10) {
+        await awardXp(
+          post.userId,
+          XP_REWARDS.receiveTenLikes,
+          'post_received_10_likes',
+          {
+            dedupeKey: `post_10_likes:${postId}`,
+            metadata: {
+              postId,
+              likeCount,
+            },
+          },
+          tx,
+        );
+      }
+
+      return { count: likeCount };
     });
 
     return apiSuccess({ liked: true, count });
   } catch (error) {
+    if (error instanceof Error && error.message === 'POST_NOT_FOUND') {
+      return apiError('Post not found', 404);
+    }
+
     return apiError('Failed to like post', 500);
   }
 }

--- a/app/app/api/posts/route.ts
+++ b/app/app/api/posts/route.ts
@@ -1,4 +1,5 @@
 import { apiError, apiSuccess } from '@/lib/api-response';
+import { awardXp, XP_REWARDS } from '@/lib/xp';
 
 import { NextRequest } from 'next/server';
 import { getCurrentUser } from '@/lib/auth';
@@ -26,32 +27,64 @@ const POST = async (request: NextRequest) => {
       return apiError('Description must be at least 50 characters', 400);
     }
 
-    const requirements = await prisma.postRequirements.create({
-      data: {
-        proofRequired: Boolean(proofRequired),
-      },
-    });
+    const post = await prisma.$transaction(async (tx) => {
+      const requirements = await tx.postRequirements.create({
+        data: {
+          proofRequired: Boolean(proofRequired),
+        },
+      });
 
-    const post = await prisma.post.create({
-      data: {
-        userId: user.id,
-        type,
-        title,
-        slug: body.slug || title.toLowerCase().replace(/\s+/g, '-').slice(0, 50),
-        description,
-        maxWinners: winnerCount ? Number(winnerCount) : null,
-        postRequirementsId: requirements.id,
-        endsAt: new Date(endsAt),
-      },
-      include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            avatarUrl: true,
+      const createdPost = await tx.post.create({
+        data: {
+          userId: user.id,
+          type,
+          title,
+          slug: body.slug || title.toLowerCase().replace(/\s+/g, '-').slice(0, 50),
+          description,
+          maxWinners: winnerCount ? Number(winnerCount) : null,
+          postRequirementsId: requirements.id,
+          endsAt: new Date(endsAt),
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              avatarUrl: true,
+            },
           },
         },
-      },
+      });
+
+      if (type === 'giveaway') {
+        await awardXp(
+          user.id,
+          XP_REWARDS.createGiveawayPost,
+          'giveaway_post_created',
+          {
+            metadata: {
+              postId: createdPost.id,
+              postType: type,
+            },
+          },
+          tx,
+        );
+      } else if (type === 'request') {
+        await awardXp(
+          user.id,
+          XP_REWARDS.createHelpRequest,
+          'help_request_created',
+          {
+            metadata: {
+              postId: createdPost.id,
+              postType: type,
+            },
+          },
+          tx,
+        );
+      }
+
+      return createdPost;
     });
 
     return apiSuccess(post, "Post created successfully", 201);

--- a/app/app/leaderboard/page.tsx
+++ b/app/app/leaderboard/page.tsx
@@ -96,8 +96,7 @@ export default function LeaderboardPage() {
   }, [selectedPeriod]);
 
   // Derive the per-tab arrays from the single API response.
-  // The API returns a unified list sorted by total_contributions.
-  // We re-sort per tab to surface the right metric for each view.
+  // The API ranks users by XP, but individual tabs still re-sort for their local metric.
   const users = data?.leaderboard ?? [];
 
   /** Top Givers — users who have created the most posts (giveaways). */
@@ -112,7 +111,10 @@ export default function LeaderboardPage() {
 
   /** Trending — users with the highest overall activity (posts + entries). */
   const trendingUsers = [...users]
-    .sort((a, b) => b.total_contributions - a.total_contributions)
+    .sort((a, b) => {
+      if (b.xp !== a.xp) return b.xp - a.xp;
+      return b.total_contributions - a.total_contributions;
+    })
     .slice(0, 20);
 
   // ── Render helpers ──────────────────────────────────────────────────────────
@@ -377,8 +379,8 @@ export default function LeaderboardPage() {
                   <div className="space-y-4">
                     {trendingUsers.map((u, idx) =>
                       renderUserRow(u, idx, {
-                        value: u.total_contributions,
-                        label: 'Activity',
+                        value: u.xp,
+                        label: 'XP',
                         colorClass: 'text-yellow-600',
                       })
                     )}

--- a/app/docs/leaderboard-api.md
+++ b/app/docs/leaderboard-api.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Leaderboard API provides ranked lists of top contributors based on their activity on the platform. Users are ranked by their total contributions (posts + entries) and can be filtered by time periods.
+The Leaderboard API provides ranked lists of top contributors based on their standing on the platform. Users are ranked by XP, while contribution counts are still returned for breakdown and tie-breaking purposes.
 
 ## Endpoint
 
@@ -86,7 +86,7 @@ curl "http://localhost:3000/api/leaderboard?period=monthly"
 
 ## Ranking Logic
 
-Users are ranked by their `total_contributions` in descending order. The `total_contributions` is calculated as:
+Users are ranked by `xp` in descending order. If two users have the same XP, `total_contributions` is used as a tie-breaker. The `total_contributions` value is calculated as:
 
 ```
 total_contributions = post_count + entry_count

--- a/app/lib/xp.ts
+++ b/app/lib/xp.ts
@@ -1,0 +1,164 @@
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+
+export const XP_REWARDS = {
+  createGiveawayPost: 50,
+  enterGiveaway: 10,
+  winGiveaway: 100,
+  createHelpRequest: 20,
+  contributeToHelpRequest: 30,
+  receiveContribution: 15,
+  receiveTenLikes: 25,
+} as const;
+
+export type XpReason =
+  | 'giveaway_post_created'
+  | 'giveaway_entered'
+  | 'giveaway_won'
+  | 'help_request_created'
+  | 'help_request_contributed'
+  | 'help_request_received_contribution'
+  | 'post_received_10_likes';
+
+type PrismaDbClient = typeof prisma | Prisma.TransactionClient;
+
+type AwardXpOptions = {
+  dedupeKey?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type AwardXpResult = {
+  awarded: boolean;
+  amount: number;
+  reason: XpReason;
+  xp: number | null;
+  rankId: string | null;
+};
+
+const XP_ANALYTICS_EVENT_TYPE = 'xp_awarded';
+
+async function getRankIdForXp(db: PrismaDbClient, xp: number) {
+  const rank = await db.rank.findFirst({
+    where: {
+      minPoints: { lte: xp },
+      maxPoints: { gte: xp },
+    },
+    orderBy: {
+      level: 'desc',
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return rank?.id ?? null;
+}
+
+async function alreadyAwarded(
+  db: PrismaDbClient,
+  userId: string,
+  dedupeKey: string,
+) {
+  const existingEvent = await db.analyticsEvent.findFirst({
+    where: {
+      userId,
+      eventType: XP_ANALYTICS_EVENT_TYPE,
+      eventData: {
+        path: ['dedupeKey'],
+        equals: dedupeKey,
+      },
+    } as any,
+    select: {
+      id: true,
+    },
+  } as any);
+
+  return Boolean(existingEvent);
+}
+
+async function awardXpInDb(
+  db: PrismaDbClient,
+  userId: string,
+  amount: number,
+  reason: XpReason,
+  options: AwardXpOptions,
+): Promise<AwardXpResult> {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('XP amount must be greater than zero');
+  }
+
+  if (options.dedupeKey && await alreadyAwarded(db, userId, options.dedupeKey)) {
+    return {
+      awarded: false,
+      amount: 0,
+      reason,
+      xp: null,
+      rankId: null,
+    };
+  }
+
+  const updatedUser = await db.user.update({
+    where: { id: userId },
+    data: {
+      xp: {
+        increment: amount,
+      },
+    },
+    select: {
+      xp: true,
+      rankId: true,
+    },
+  });
+
+  const nextRankId = await getRankIdForXp(db, updatedUser.xp);
+  const finalUser = nextRankId !== updatedUser.rankId
+    ? await db.user.update({
+      where: { id: userId },
+      data: {
+        rankId: nextRankId,
+      },
+      select: {
+        xp: true,
+        rankId: true,
+      },
+    })
+    : updatedUser;
+
+  await db.analyticsEvent.create({
+    data: {
+      userId,
+      eventType: XP_ANALYTICS_EVENT_TYPE,
+      eventData: {
+        reason,
+        amount,
+        xp: finalUser.xp,
+        rankId: finalUser.rankId,
+        dedupeKey: options.dedupeKey ?? null,
+        metadata: options.metadata ?? null,
+      },
+    },
+  } as any);
+
+  return {
+    awarded: true,
+    amount,
+    reason,
+    xp: finalUser.xp,
+    rankId: finalUser.rankId,
+  };
+}
+
+export async function awardXp(
+  userId: string,
+  amount: number,
+  reason: XpReason,
+  options: AwardXpOptions = {},
+  db: PrismaDbClient = prisma,
+) {
+  if (db === prisma) {
+    return prisma.$transaction((tx) => awardXpInDb(tx, userId, amount, reason, options));
+  }
+
+  return awardXpInDb(db, userId, amount, reason, options);
+}

--- a/app/tests/api/entries.test.ts
+++ b/app/tests/api/entries.test.ts
@@ -6,12 +6,32 @@ import { createTestEntry, createTestPost, createTestUser } from '../helpers/db';
 import { DELETE as DeleteEntry } from '@/app/api/entries/[id]/route';
 import { prisma } from '@/lib/prisma';
 
+const mockAwardXp = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/xp', () => ({
+  awardXp: mockAwardXp,
+  XP_REWARDS: {
+    createGiveawayPost: 50,
+    createHelpRequest: 20,
+    enterGiveaway: 10,
+    receiveTenLikes: 25,
+  },
+}));
+
 describe('Entry API Endpoints', () => {
   let user1: any, user2: any, user3: any, post: any, requestPost: any;
 
   beforeEach(async () => {
     // Reset all mocks before each test
     vi.clearAllMocks();
+    mockAwardXp.mockResolvedValue({
+      awarded: true,
+      amount: 10,
+      reason: 'giveaway_entered',
+      xp: 10,
+      rankId: 'newcomer',
+    });
+    prisma.$transaction = vi.fn(async (callback: any) => callback(prisma as any));
 
     // Always use mock data objects - no database calls in beforeEach
     user1 = {
@@ -127,6 +147,18 @@ describe('Entry API Endpoints', () => {
       expect(data.data.userId).toBe(user2.id);
       expect(data.data.postId).toBe(post.id);
       expect(data.message).toBe('Entry created successfully');
+      expect(mockAwardXp).toHaveBeenCalledWith(
+        user2.id,
+        10,
+        'giveaway_entered',
+        expect.objectContaining({
+          metadata: {
+            postId: post.id,
+            entryId: mockEntry.id,
+          },
+        }),
+        expect.anything(),
+      );
     });
 
     it('should create an entry without proofUrl', async () => {

--- a/app/tests/api/interactions.unit.test.ts
+++ b/app/tests/api/interactions.unit.test.ts
@@ -3,20 +3,42 @@ import { POST as likePost, DELETE as unlikePost } from '@/app/api/posts/[id]/lik
 import { POST as burnPost, DELETE as unburnPost } from '@/app/api/posts/[id]/burn/route';
 import { GET as getStats } from '@/app/api/posts/[id]/stats/route';
 
+const mockAwardXp = vi.hoisted(() => vi.fn());
+
 // Mock dependencies
-const mockPrisma = vi.hoisted(() => ({
-  interaction: {
-    upsert: vi.fn(),
-    count: vi.fn(),
-    deleteMany: vi.fn(),
-  },
-  entry: {
-    count: vi.fn(),
-  }
-}));
+const mockPrisma = vi.hoisted(() => {
+  const prisma = {
+    $transaction: vi.fn(),
+    interaction: {
+      upsert: vi.fn(),
+      count: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    entry: {
+      count: vi.fn(),
+    },
+    post: {
+      findUnique: vi.fn(),
+    },
+  };
+
+  prisma.$transaction.mockImplementation(async (callback: any) => callback(prisma));
+
+  return prisma;
+});
 
 vi.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
+}));
+
+vi.mock('@/lib/xp', () => ({
+  awardXp: mockAwardXp,
+  XP_REWARDS: {
+    createGiveawayPost: 50,
+    createHelpRequest: 20,
+    enterGiveaway: 10,
+    receiveTenLikes: 25,
+  },
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -38,10 +60,22 @@ describe('Interactions API (Unit)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (getCurrentUser as any).mockResolvedValue(mockUser);
+    mockAwardXp.mockResolvedValue({
+      awarded: true,
+      amount: 25,
+      reason: 'post_received_10_likes',
+      xp: 25,
+      rankId: 'newcomer',
+    });
+    mockPrisma.$transaction.mockImplementation(async (callback: any) => callback(mockPrisma));
   });
 
   describe('Like API', () => {
     it('should like a post', async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: postId,
+        userId: 'author-1',
+      });
       mockPrisma.interaction.upsert.mockResolvedValue({});
       mockPrisma.interaction.count.mockResolvedValue(10);
 
@@ -69,6 +103,15 @@ describe('Interactions API (Unit)', () => {
           type: 'like',
         },
       });
+      expect(mockAwardXp).toHaveBeenCalledWith(
+        'author-1',
+        25,
+        'post_received_10_likes',
+        expect.objectContaining({
+          dedupeKey: `post_10_likes:${postId}`,
+        }),
+        expect.anything(),
+      );
     });
 
     it('should return 401 if not authorized', async () => {
@@ -76,6 +119,15 @@ describe('Interactions API (Unit)', () => {
       const request = createRequest('POST');
       const response = await likePost(request as any, { params });
       expect(response.status).toBe(401);
+    });
+
+    it('should return 404 when liking a missing post', async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(null);
+
+      const request = createRequest('POST');
+      const response = await likePost(request as any, { params });
+
+      expect(response.status).toBe(404);
     });
 
     it('should unlike a post', async () => {

--- a/app/tests/api/posts.test.ts
+++ b/app/tests/api/posts.test.ts
@@ -1,9 +1,22 @@
-import { GET, POST } from '@/app/api/posts/route';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMockRequest, parseResponse } from '../helpers/api';
 
 import { createTestUser } from '../helpers/db';
 import { prisma } from '@/lib/prisma';
+
+const mockAwardXp = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/xp', () => ({
+  awardXp: mockAwardXp,
+  XP_REWARDS: {
+    createGiveawayPost: 50,
+    createHelpRequest: 20,
+    enterGiveaway: 10,
+    receiveTenLikes: 25,
+  },
+}));
+
+import { GET, POST } from '@/app/api/posts/route';
 
 describe('Posts API', () => {
   let testUser: any;
@@ -11,6 +24,18 @@ describe('Posts API', () => {
   beforeEach(async () => {
     // Reset all mocks before each test
     vi.clearAllMocks();
+    mockAwardXp.mockResolvedValue({
+      awarded: true,
+      amount: 50,
+      reason: 'giveaway_post_created',
+      xp: 50,
+      rankId: 'newcomer',
+    });
+    prisma.$transaction = vi.fn(async (callback: any) => callback(prisma as any));
+    prisma.postRequirements.create = vi.fn().mockResolvedValue({
+      id: 'requirements_123',
+      proofRequired: false,
+    });
 
     // Mock user creation for unit tests where DB is not available
     if (process.env.MOCK_DB === 'true') {
@@ -116,6 +141,67 @@ describe('Posts API', () => {
 
       expect(status).toBe(201);
       expect(data.data.title).toBe(postData.title);
+      expect(mockAwardXp).toHaveBeenCalledWith(
+        testUser.id,
+        50,
+        'giveaway_post_created',
+        expect.objectContaining({
+          metadata: {
+            postId: mockCreatedPost.id,
+            postType: 'giveaway',
+          },
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('should award help-request XP when creating a request post', async () => {
+      const postData = {
+        title: 'Need help with my laptop setup',
+        description:
+          'I need community support to replace a broken laptop and keep working on my projects this month.',
+        category: 'services',
+        type: 'request',
+        slug: 'need-help-with-my-laptop-setup',
+        endsAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+
+      const mockCreatedPost = {
+        id: 'post_request_123',
+        ...postData,
+        endsAt: new Date(postData.endsAt),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: testUser,
+        userId: testUser.id,
+      };
+
+      prisma.post.create = vi.fn().mockResolvedValue(mockCreatedPost);
+
+      const request = createMockRequest('http://localhost:3000/api/posts', {
+        method: 'POST',
+        body: postData,
+        cookies: { session: 'mock-session-token' },
+      });
+
+      vi.spyOn(await import('@/lib/auth'), 'getCurrentUser').mockResolvedValue(testUser);
+
+      const response = await POST(request);
+      const { status } = await parseResponse(response);
+
+      expect(status).toBe(201);
+      expect(mockAwardXp).toHaveBeenCalledWith(
+        testUser.id,
+        20,
+        'help_request_created',
+        expect.objectContaining({
+          metadata: {
+            postId: mockCreatedPost.id,
+            postType: 'request',
+          },
+        }),
+        expect.anything(),
+      );
     });
 
     it('should validate title length', async () => {
@@ -131,6 +217,8 @@ describe('Posts API', () => {
         method: 'POST',
         body: postData,
       });
+
+      vi.spyOn(await import('@/lib/auth'), 'getCurrentUser').mockResolvedValue(testUser);
 
       const response = await POST(request);
       const { status } = await parseResponse(response);

--- a/app/tests/lib/xp.test.ts
+++ b/app/tests/lib/xp.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPrisma = vi.hoisted(() => ({
+  $transaction: vi.fn(),
+}));
+
+const mockTx = vi.hoisted(() => ({
+  user: {
+    update: vi.fn(),
+  },
+  rank: {
+    findFirst: vi.fn(),
+  },
+  analyticsEvent: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: mockPrisma,
+}));
+
+import { awardXp } from '@/lib/xp';
+
+describe('awardXp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.$transaction.mockImplementation(async (callback: any) => callback(mockTx));
+  });
+
+  it('increments XP, updates rank, and records an analytics event', async () => {
+    mockTx.analyticsEvent.findFirst.mockResolvedValue(null);
+    mockTx.user.update
+      .mockResolvedValueOnce({
+        xp: 250,
+        rankId: 'newcomer',
+      })
+      .mockResolvedValueOnce({
+        xp: 250,
+        rankId: 'helper',
+      });
+    mockTx.rank.findFirst.mockResolvedValue({ id: 'helper' });
+    mockTx.analyticsEvent.create.mockResolvedValue({ id: 'event_1' });
+
+    const result = await awardXp('user_1', 50, 'giveaway_post_created', {
+      metadata: {
+        postId: 'post_1',
+      },
+    });
+
+    expect(result).toEqual({
+      awarded: true,
+      amount: 50,
+      reason: 'giveaway_post_created',
+      xp: 250,
+      rankId: 'helper',
+    });
+    expect(mockTx.user.update).toHaveBeenNthCalledWith(1, {
+      where: { id: 'user_1' },
+      data: {
+        xp: {
+          increment: 50,
+        },
+      },
+      select: {
+        xp: true,
+        rankId: true,
+      },
+    });
+    expect(mockTx.user.update).toHaveBeenNthCalledWith(2, {
+      where: { id: 'user_1' },
+      data: {
+        rankId: 'helper',
+      },
+      select: {
+        xp: true,
+        rankId: true,
+      },
+    });
+    expect(mockTx.analyticsEvent.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        userId: 'user_1',
+        eventType: 'xp_awarded',
+      }),
+    }));
+  });
+
+  it('does not award duplicate XP when a dedupe key already exists', async () => {
+    mockTx.analyticsEvent.findFirst.mockResolvedValue({ id: 'event_1' });
+
+    const result = await awardXp('user_1', 25, 'post_received_10_likes', {
+      dedupeKey: 'post_10_likes:post_1',
+    });
+
+    expect(result).toEqual({
+      awarded: false,
+      amount: 0,
+      reason: 'post_received_10_likes',
+      xp: null,
+      rankId: null,
+    });
+    expect(mockTx.user.update).not.toHaveBeenCalled();
+    expect(mockTx.analyticsEvent.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared `awardXp` helper that increments XP, recalculates rank, and records XP analytics events
- award XP for giveaway post creation, help request creation, giveaway entry submission, and the 10-like milestone
- update the leaderboard API and UI to rank users by XP
- add tests for the new XP flow and update leaderboard documentation

## Notes
- I wired XP into the server-side write paths that currently exist in this repo.
- I did not add winner/contribution XP awarding because I could not find corresponding server endpoints for those flows in the current codebase.

## Validation
- Not completed locally. Dependency install was started, but the targeted test run was interrupted before it finished.

Closes #190
