### PR TITLE
feat: add wallet balance tracking and transaction history (#193)

### DIFF
--- a/app/app/api/wallet/balance/route.ts
+++ b/app/app/api/wallet/balance/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from 'next/server';
+import { apiError, apiSuccess } from '@/lib/api-response';
+import { getCurrentUser } from '@/lib/auth';
+
+export async function GET(request: NextRequest) {
+    try {
+        const currentUser = await getCurrentUser(request);
+        if (!currentUser) return apiError('Unauthorized', 401);
+
+        return apiSuccess({ balance: currentUser.walletBalance });
+    } catch {
+        return apiError('Failed to fetch wallet balance', 500);
+    }
+}

--- a/app/app/api/wallet/fund/route.ts
+++ b/app/app/api/wallet/fund/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { apiError, apiSuccess } from '@/lib/api-response';
+import { getCurrentUser } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+const fundSchema = z.object({
+    amount: z.number().positive('Amount must be greater than 0'),
+    method: z.enum(['card', 'bank', 'crypto']).default('card'),
+    note: z.string().optional(),
+});
+
+export async function POST(request: NextRequest) {
+    try {
+        const currentUser = await getCurrentUser(request);
+        if (!currentUser) return apiError('Unauthorized', 401);
+
+        const body = await request.json();
+        const parsed = fundSchema.safeParse(body);
+        if (!parsed.success) {
+            return apiError(parsed.error.errors[0].message, 400);
+        }
+
+        const { amount, method, note } = parsed.data;
+
+        const [transaction, updatedUser] = await prisma.$transaction([
+            prisma.walletTransaction.create({
+                data: {
+                    userId: currentUser.id,
+                    type: 'fund',
+                    amount,
+                    currency: 'USD',
+                    status: 'completed',
+                    method,
+                    note: note ?? null,
+                },
+            }),
+            prisma.user.update({
+                where: { id: currentUser.id },
+                data: { walletBalance: { increment: amount } },
+                select: { walletBalance: true },
+            }),
+        ]);
+
+        return apiSuccess(
+            { balance: updatedUser.walletBalance, transaction },
+            'Wallet funded successfully',
+            201,
+        );
+    } catch {
+        return apiError('Failed to fund wallet', 500);
+    }
+}

--- a/app/app/api/wallet/transactions/route.ts
+++ b/app/app/api/wallet/transactions/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from 'next/server';
+import { apiError, apiSuccess } from '@/lib/api-response';
+import { getCurrentUser } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(request: NextRequest) {
+    try {
+        const currentUser = await getCurrentUser(request);
+        if (!currentUser) return apiError('Unauthorized', 401);
+
+        const { searchParams } = new URL(request.url);
+        const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+        const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
+        const skip = (page - 1) * limit;
+
+        const [transactions, total] = await Promise.all([
+            prisma.walletTransaction.findMany({
+                where: { userId: currentUser.id },
+                orderBy: { createdAt: 'desc' },
+                skip,
+                take: limit,
+            }),
+            prisma.walletTransaction.count({ where: { userId: currentUser.id } }),
+        ]);
+
+        return apiSuccess({ transactions, total, page, limit });
+    } catch {
+        return apiError('Failed to fetch transactions', 500);
+    }
+}

--- a/app/app/api/wallet/withdraw/route.ts
+++ b/app/app/api/wallet/withdraw/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { apiError, apiSuccess } from '@/lib/api-response';
+import { getCurrentUser } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+const withdrawSchema = z.object({
+    amount: z.number().positive('Amount must be greater than 0'),
+    method: z.enum(['bank', 'crypto', 'card']).default('bank'),
+    note: z.string().optional(),
+});
+
+export async function POST(request: NextRequest) {
+    try {
+        const currentUser = await getCurrentUser(request);
+        if (!currentUser) return apiError('Unauthorized', 401);
+
+        const body = await request.json();
+        const parsed = withdrawSchema.safeParse(body);
+        if (!parsed.success) {
+            return apiError(parsed.error.errors[0].message, 400);
+        }
+
+        const { amount, method, note } = parsed.data;
+
+        const result = await prisma.$transaction(async (tx) => {
+            const user = await tx.user.findUnique({
+                where: { id: currentUser.id },
+                select: { walletBalance: true },
+            });
+
+            if (!user) throw new Error('USER_NOT_FOUND');
+            if (user.walletBalance < amount) throw new Error('INSUFFICIENT_BALANCE');
+
+            const transaction = await tx.walletTransaction.create({
+                data: {
+                    userId: currentUser.id,
+                    type: 'withdraw',
+                    amount,
+                    currency: 'USD',
+                    status: 'pending',
+                    method,
+                    note: note ?? null,
+                },
+            });
+
+            const updatedUser = await tx.user.update({
+                where: { id: currentUser.id },
+                data: { walletBalance: { decrement: amount } },
+                select: { walletBalance: true },
+            });
+
+            return { transaction, balance: updatedUser.walletBalance };
+        });
+
+        return apiSuccess(result, 'Withdrawal initiated successfully');
+    } catch (error) {
+        if (error instanceof Error) {
+            if (error.message === 'INSUFFICIENT_BALANCE') {
+                return apiError('Insufficient wallet balance', 400);
+            }
+            if (error.message === 'USER_NOT_FOUND') {
+                return apiError('User not found', 404);
+            }
+        }
+        return apiError('Failed to process withdrawal', 500);
+    }
+}

--- a/app/components/payment-modal.tsx
+++ b/app/components/payment-modal.tsx
@@ -35,7 +35,7 @@ export function PaymentModal({
   description,
   onSuccess,
 }: PaymentModalProps) {
-  const { user } = useAppContext();
+  const { user, setCurrentUser } = useAppContext();
   const [paymentMethod, setPaymentMethod] = useState("wallet");
   const [isProcessing, setIsProcessing] = useState(false);
   const [cardDetails, setCardDetails] = useState({
@@ -51,12 +51,23 @@ export function PaymentModal({
     setIsProcessing(true);
 
     try {
-      // Simulate payment processing
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      if (paymentMethod === "wallet") {
+        if (!canPayWithWallet) throw new Error("Insufficient wallet balance");
 
-      if (paymentMethod === "wallet" && !canPayWithWallet) {
-        throw new Error("Insufficient wallet balance");
+        const res = await fetch("/api/wallet/withdraw", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ amount, method: "card", note: title }),
+        });
+
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error ?? "Payment failed");
+
+        if (user) {
+          setCurrentUser({ ...user, walletBalance: data.data.balance });
+        }
       }
+      // card payments: integrate a payment provider here
 
       toast("Payment successful!", {
         description: `$${amount.toFixed(2)} has been processed successfully.`,

--- a/app/components/wallet-management.tsx
+++ b/app/components/wallet-management.tsx
@@ -36,66 +36,126 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { WalletTransaction } from "@/lib/types";
 import { toast } from "sonner";
 import { useAppContext } from "@/contexts/app-context";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+const INCOMING_TYPES = new Set(["fund", "prize_in"]);
+
+const TX_LABEL: Record<WalletTransaction["type"], string> = {
+  fund: "Deposit",
+  prize_in: "Prize Received",
+  withdraw: "Withdrawal",
+  contribution_out: "Contribution",
+};
+
+function getMonthBounds() {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), 1);
+  const end = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+  return { start, end };
+}
 
 export function WalletManagement() {
-  const { user } = useAppContext();
+  const { user, setCurrentUser } = useAppContext();
   const [showFundModal, setShowFundModal] = useState(false);
   const [showWithdrawModal, setShowWithdrawModal] = useState(false);
   const [fundAmount, setFundAmount] = useState("");
   const [fundMethod, setFundMethod] = useState("card");
   const [withdrawAmount, setWithdrawAmount] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
+  const [transactions, setTransactions] = useState<WalletTransaction[]>([]);
+  const [isLoadingTx, setIsLoadingTx] = useState(true);
 
-  const transactions = [
-    {
-      id: "1",
-      type: "deposit",
-      amount: 100,
-      method: "Credit Card",
-      date: new Date("2024-01-15"),
-      status: "completed",
-    },
-    {
-      id: "2",
-      type: "withdrawal",
-      amount: 25,
-      method: "Bank Transfer",
-      date: new Date("2024-01-14"),
-      status: "completed",
-    },
-    {
-      id: "3",
-      type: "deposit",
-      amount: 50,
-      method: "Crypto Wallet",
-      date: new Date("2024-01-13"),
-      status: "pending",
-    },
-  ];
+  useEffect(() => {
+    const fetchTransactions = async () => {
+      try {
+        const res = await fetch("/api/wallet/transactions?limit=20");
+        if (!res.ok) throw new Error("Failed to fetch");
+        const data = await res.json();
+        setTransactions(
+          (data.data?.transactions ?? []).map((tx: WalletTransaction) => ({
+            ...tx,
+            createdAt: new Date(tx.createdAt),
+            updatedAt: new Date(tx.updatedAt),
+          }))
+        );
+      } catch {
+        // silently fail — transactions will just be empty
+      } finally {
+        setIsLoadingTx(false);
+      }
+    };
+
+    fetchTransactions();
+  }, []);
+
+  const { start, end } = getMonthBounds();
+  const thisMonthTx = transactions.filter(
+    (tx) =>
+      tx.status !== "failed" &&
+      new Date(tx.createdAt) >= start &&
+      new Date(tx.createdAt) <= end
+  );
+  const receivedThisMonth = thisMonthTx
+    .filter((tx) => INCOMING_TYPES.has(tx.type))
+    .reduce((sum, tx) => sum + tx.amount, 0);
+  const sentThisMonth = thisMonthTx
+    .filter((tx) => !INCOMING_TYPES.has(tx.type))
+    .reduce((sum, tx) => sum + tx.amount, 0);
 
   const handleFundWallet = async () => {
-    if (!fundAmount || Number.parseFloat(fundAmount) <= 0) return;
+    const amount = parseFloat(fundAmount);
+    if (!fundAmount || amount <= 0) return;
 
     setIsProcessing(true);
+    try {
+      const res = await fetch("/api/wallet/fund", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount, method: fundMethod }),
+      });
 
-    // Simulate payment processing
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+      const data = await res.json();
 
-    toast("Wallet funded successfully!", {
-      description: `$${fundAmount} has been added to your wallet.`,
-    });
+      if (!res.ok) {
+        toast.error("Failed to add funds", {
+          description: data.error ?? "Please try again.",
+        });
+        return;
+      }
 
-    setFundAmount("");
-    setShowFundModal(false);
-    setIsProcessing(false);
+      const newTx: WalletTransaction = {
+        ...data.data.transaction,
+        createdAt: new Date(data.data.transaction.createdAt),
+        updatedAt: new Date(data.data.transaction.updatedAt),
+      };
+      setTransactions((prev) => [newTx, ...prev]);
+
+      if (user) {
+        setCurrentUser({ ...user, walletBalance: data.data.balance });
+      }
+
+      toast("Wallet funded successfully!", {
+        description: `$${amount.toFixed(2)} has been added to your wallet.`,
+      });
+
+      setFundAmount("");
+      setShowFundModal(false);
+    } catch {
+      toast.error("Something went wrong", {
+        description: "Please try again.",
+      });
+    } finally {
+      setIsProcessing(false);
+    }
   };
 
   const handleWithdraw = async () => {
-    if (!withdrawAmount || Number.parseFloat(withdrawAmount) <= 0) return;
-    if (Number.parseFloat(withdrawAmount) > (user?.walletBalance || 0)) {
+    const amount = parseFloat(withdrawAmount);
+    if (!withdrawAmount || amount <= 0) return;
+    if (amount > (user?.walletBalance ?? 0)) {
       toast.error("Insufficient funds", {
         description: "You don't have enough balance for this withdrawal.",
       });
@@ -103,17 +163,46 @@ export function WalletManagement() {
     }
 
     setIsProcessing(true);
+    try {
+      const res = await fetch("/api/wallet/withdraw", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount, method: "bank" }),
+      });
 
-    // Simulate withdrawal processing
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+      const data = await res.json();
 
-    toast("Withdrawal initiated", {
-      description: `$${withdrawAmount} withdrawal is being processed.`,
-    });
+      if (!res.ok) {
+        toast.error("Withdrawal failed", {
+          description: data.error ?? "Please try again.",
+        });
+        return;
+      }
 
-    setWithdrawAmount("");
-    setShowWithdrawModal(false);
-    setIsProcessing(false);
+      const newTx: WalletTransaction = {
+        ...data.data.transaction,
+        createdAt: new Date(data.data.transaction.createdAt),
+        updatedAt: new Date(data.data.transaction.updatedAt),
+      };
+      setTransactions((prev) => [newTx, ...prev]);
+
+      if (user) {
+        setCurrentUser({ ...user, walletBalance: data.data.balance });
+      }
+
+      toast("Withdrawal initiated", {
+        description: `$${amount.toFixed(2)} withdrawal is being processed.`,
+      });
+
+      setWithdrawAmount("");
+      setShowWithdrawModal(false);
+    } catch {
+      toast.error("Something went wrong", {
+        description: "Please try again.",
+      });
+    } finally {
+      setIsProcessing(false);
+    }
   };
 
   return (
@@ -129,7 +218,7 @@ export function WalletManagement() {
         </div>
 
         <div className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-          ${user?.walletBalance?.toFixed(2) || "0.00"}
+          ${(user?.walletBalance ?? 0).toFixed(2)}
         </div>
 
         <div className="flex gap-3">
@@ -156,13 +245,15 @@ export function WalletManagement() {
         </div>
       </div>
 
-      {/* Quick Actions */}
+      {/* Quick Stats */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <Card className="border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
           <CardContent className="p-4 text-center">
             <ArrowDownLeft className="w-8 h-8 mx-auto mb-2 text-green-500" />
             <div className="font-semibold">Received</div>
-            <div className="text-2xl font-bold text-green-600">$245.00</div>
+            <div className="text-2xl font-bold text-green-600">
+              ${receivedThisMonth.toFixed(2)}
+            </div>
             <div className="text-sm text-gray-500">This month</div>
           </CardContent>
         </Card>
@@ -171,7 +262,9 @@ export function WalletManagement() {
           <CardContent className="p-4 text-center">
             <ArrowUpRight className="w-8 h-8 mx-auto mb-2 text-blue-500" />
             <div className="font-semibold">Sent</div>
-            <div className="text-2xl font-bold text-blue-600">$89.50</div>
+            <div className="text-2xl font-bold text-blue-600">
+              ${sentThisMonth.toFixed(2)}
+            </div>
             <div className="text-sm text-gray-500">This month</div>
           </CardContent>
         </Card>
@@ -181,7 +274,7 @@ export function WalletManagement() {
             <DollarSign className="w-8 h-8 mx-auto mb-2 text-orange-500" />
             <div className="font-semibold">Available</div>
             <div className="text-2xl font-bold text-orange-600">
-              ${user?.walletBalance?.toFixed(2) || "0.00"}
+              ${(user?.walletBalance ?? 0).toFixed(2)}
             </div>
             <div className="text-sm text-gray-500">Ready to use</div>
           </CardContent>
@@ -198,65 +291,76 @@ export function WalletManagement() {
           <CardDescription>Your latest wallet activity</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="space-y-4">
-            {transactions.map((transaction) => (
-              <div
-                key={transaction.id}
-                className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-100 dark:border-gray-700"
-              >
-                <div className="flex items-center gap-3">
+          {isLoadingTx ? (
+            <div className="text-center py-8 text-gray-500 text-sm">
+              Loading transactions...
+            </div>
+          ) : transactions.length === 0 ? (
+            <div className="text-center py-8 text-gray-500 text-sm">
+              No transactions yet. Add funds to get started.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {transactions.map((transaction) => {
+                const isIncoming = INCOMING_TYPES.has(transaction.type);
+                return (
                   <div
-                    className={`p-2 rounded-full ${
-                      transaction.type === "deposit"
-                        ? "bg-green-100 text-green-600"
-                        : "bg-blue-100 text-blue-600"
-                    }`}
+                    key={transaction.id}
+                    className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-100 dark:border-gray-700"
                   >
-                    {transaction.type === "deposit" ? (
-                      <ArrowDownLeft className="w-4 h-4" />
-                    ) : (
-                      <ArrowUpRight className="w-4 h-4" />
-                    )}
-                  </div>
-                  <div>
-                    <div className="font-medium capitalize">
-                      {transaction.type}
+                    <div className="flex items-center gap-3">
+                      <div
+                        className={`p-2 rounded-full ${
+                          isIncoming
+                            ? "bg-green-100 text-green-600"
+                            : "bg-blue-100 text-blue-600"
+                        }`}
+                      >
+                        {isIncoming ? (
+                          <ArrowDownLeft className="w-4 h-4" />
+                        ) : (
+                          <ArrowUpRight className="w-4 h-4" />
+                        )}
+                      </div>
+                      <div>
+                        <div className="font-medium">
+                          {TX_LABEL[transaction.type]}
+                        </div>
+                        <div className="text-sm text-gray-500">
+                          {transaction.method ?? "—"}
+                        </div>
+                      </div>
                     </div>
-                    <div className="text-sm text-gray-500">
-                      {transaction.method}
+                    <div className="text-right">
+                      <div
+                        className={`font-semibold ${
+                          isIncoming ? "text-green-600" : "text-blue-600"
+                        }`}
+                      >
+                        {isIncoming ? "+" : "-"}$
+                        {transaction.amount.toFixed(2)}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Badge
+                          variant={
+                            transaction.status === "completed"
+                              ? "default"
+                              : "secondary"
+                          }
+                          className="text-xs"
+                        >
+                          {transaction.status}
+                        </Badge>
+                        <span className="text-xs text-gray-500">
+                          {new Date(transaction.createdAt).toLocaleDateString()}
+                        </span>
+                      </div>
                     </div>
                   </div>
-                </div>
-                <div className="text-right">
-                  <div
-                    className={`font-semibold ${
-                      transaction.type === "deposit"
-                        ? "text-green-600"
-                        : "text-blue-600"
-                    }`}
-                  >
-                    {transaction.type === "deposit" ? "+" : "-"}$
-                    {transaction.amount.toFixed(2)}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Badge
-                      variant={
-                        transaction.status === "completed"
-                          ? "default"
-                          : "secondary"
-                      }
-                      className="text-xs"
-                    >
-                      {transaction.status}
-                    </Badge>
-                    <span className="text-xs text-gray-500">
-                      {transaction.date.toLocaleDateString()}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -356,10 +460,10 @@ export function WalletManagement() {
                 placeholder="0.00"
                 value={withdrawAmount}
                 onChange={(e) => setWithdrawAmount(e.target.value)}
-                max={user?.walletBalance || 0}
+                max={user?.walletBalance ?? 0}
               />
               <div className="text-sm text-gray-500">
-                Available balance: ${user?.walletBalance?.toFixed(2) || "0.00"}
+                Available balance: ${(user?.walletBalance ?? 0).toFixed(2)}
               </div>
             </div>
 

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -20,6 +20,7 @@ const getCurrentUser = async (_request: NextRequest) => {
             bio: true,
             avatarUrl: true,
             xp: true,
+            walletBalance: true,
             createdAt: true,
             updatedAt: true,
         },

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -3,7 +3,7 @@ import type { User as BaseUser, Badge as Basebadge, Rank } from "@prisma/client"
 import { SignInResponse } from "next-auth/react"
 
 export type User = BaseUser & {
-  walletBalance?: number
+  walletBalance: number
   rank: Rank
   badges: Badge[]
   _count: {
@@ -91,6 +91,20 @@ export interface Entry {
   isWinner?: boolean
   replies?: Reply[]
   parentId?: string
+}
+
+export interface WalletTransaction {
+  id: string
+  userId: string
+  type: "fund" | "withdraw" | "contribution_out" | "prize_in"
+  amount: number
+  currency: string
+  status: "pending" | "completed" | "failed"
+  method?: string | null
+  reference?: string | null
+  note?: string | null
+  createdAt: Date
+  updatedAt: Date
 }
 
 export interface HelpContribution {

--- a/app/prisma/migrations/20260325000000_add_wallet_balance_and_transactions/migration.sql
+++ b/app/prisma/migrations/20260325000000_add_wallet_balance_and_transactions/migration.sql
@@ -1,0 +1,34 @@
+-- CreateEnum
+CREATE TYPE "TransactionType" AS ENUM ('fund', 'withdraw', 'contribution_out', 'prize_in');
+
+-- CreateEnum
+CREATE TYPE "TransactionStatus" AS ENUM ('pending', 'completed', 'failed');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "wallet_balance" DOUBLE PRECISION NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "wallet_transactions" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "type" "TransactionType" NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "currency" VARCHAR(10) NOT NULL DEFAULT 'USD',
+    "status" "TransactionStatus" NOT NULL DEFAULT 'pending',
+    "method" VARCHAR(50),
+    "reference" VARCHAR(255),
+    "note" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "wallet_transactions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "wallet_transactions_user_id_idx" ON "wallet_transactions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "wallet_transactions_created_at_idx" ON "wallet_transactions"("created_at" DESC);
+
+-- AddForeignKey
+ALTER TABLE "wallet_transactions" ADD CONSTRAINT "wallet_transactions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -112,6 +112,19 @@ enum HelpType {
   other
 }
 
+enum TransactionType {
+  fund
+  withdraw
+  contribution_out
+  prize_in
+}
+
+enum TransactionStatus {
+  pending
+  completed
+  failed
+}
+
 model Activity {
   id          String       @id @default(uuid())
   userId      String
@@ -136,7 +149,7 @@ model User {
   bio           String?
   avatarUrl     String?   @map("avatar_url")
   xp            Int       @default(0)
-  // walletBalance Float    @default(0) @map("wallet_balance")
+  walletBalance Float    @default(0) @map("wallet_balance")
   emailVerified DateTime? @map("email_verified")
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")
@@ -156,6 +169,7 @@ model User {
   accounts          Account[]
   sessions          Session[]
   wins              PostWinner[]       @relation("PostWinner")
+  walletTransactions WalletTransaction[]
 
   @@map("users")
 }
@@ -455,4 +469,24 @@ model AnalyticsEvent {
   @@index([createdAt], name: "idx_analytics_events_created")
   @@index([userId], name: "idx_analytics_events_user")
   @@map("analytics_events")
+}
+
+model WalletTransaction {
+  id        String            @id @default(uuid())
+  userId    String            @map("user_id")
+  type      TransactionType
+  amount    Float
+  currency  String            @default("USD") @db.VarChar(10)
+  status    TransactionStatus @default(pending)
+  method    String?           @db.VarChar(50)
+  reference String?           @db.VarChar(255)
+  note      String?
+  createdAt DateTime          @default(now()) @map("created_at")
+  updatedAt DateTime          @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([createdAt(sort: Desc)])
+  @@map("wallet_transactions")
 }


### PR DESCRIPTION
# Wallet Balance Tracking — Implementation Summary
 
## Database (`prisma/schema.prisma` + migration)
 
- Uncommented `walletBalance Float @default(0)` on the `User` model
- Added `TransactionType` enum: `fund | withdraw | contribution_out | prize_in`
- Added `TransactionStatus` enum: `pending | completed | failed`
- Added `WalletTransaction` model with full audit fields — `userId`, `type`, `amount`, `currency`, `status`, `method`, `reference`, `note`, timestamps
- Created migration SQL at `prisma/migrations/20260325000000_add_wallet_balance_and_transactions/`
 
## API Routes (all new)
 
| Method | Route | Description |
|--------|-------|-------------|
| `GET` | `/api/wallet/balance` | Returns current user's balance |
| `GET` | `/api/wallet/transactions` | Paginated real transaction history |
| `POST` | `/api/wallet/fund` | Atomically increments balance + writes ledger record |
| `POST` | `/api/wallet/withdraw` | Interactive Prisma transaction — checks balance then atomically debits + writes ledger (race-condition safe) |
 
## Types (`lib/types.ts`)
 
- Added `WalletTransaction` interface
- Made `walletBalance` non-optional on `User` (it now has `@default(0)`)
 
## Auth (`lib/auth.ts`)
 
- `walletBalance` added to `getCurrentUser()` select
 
## UI — `wallet-management.tsx`
 
- Fetches real transactions from API on mount
- Monthly received/sent stats computed from live data
- `handleFundWallet` and `handleWithdraw` call real endpoints and update the user in context via `setCurrentUser`
- Empty and loading states for the transaction list
 
## UI — `payment-modal.tsx`
 
- Wallet payment path now calls `POST /api/wallet/withdraw` and updates context balance — no more `setTimeout` simulation
 
## Deployment
 
Run `prisma migrate deploy` (or `prisma migrate dev`) once `DATABASE_URL` is set in `.env`.


Closes #193 