### PR TITLE
fix: prevent stale localStorage writes and stop persisting API-source…

### DIFF
--- a/app/contexts/app-context.tsx
+++ b/app/contexts/app-context.tsx
@@ -209,8 +209,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     setIsHydrated(true);
   }, []);
 
-  // Save state to localStorage on changes (debounced)
+  // Save state to localStorage on changes (debounced, only after hydration)
   useEffect(() => {
+    if (!isHydrated) return;
+
     const timeoutId = setTimeout(() => {
       try {
         localStorage.setItem(STORAGE_KEY, serializeState(state));

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -26,10 +26,11 @@ export function isPostExpired (endDate: Date): boolean {
  * Converts Sets to Arrays for JSON serialization
  */
 export const serializeState = (state: AppState): string => {
-  const { user, ...stateWithoutUser } = state;
+  // Exclude user (re-fetched from session) and posts (re-fetched from API)
+  const { user: _user, posts: _posts, ...stateWithoutRemoteData } = state;
 
   const serializable = {
-    ...stateWithoutUser,
+    ...stateWithoutRemoteData,
     likes: Array.from(state.likes),
     burns: Array.from(state.burns),
   };


### PR DESCRIPTION
 **Summary**
 
 
- Adds 'if (!isHydrated) return` guard to the localStorage save effect in `AppContext` so empty initial state is never written before hydration completes
- Removes `posts` from `serializeState` — posts are now loaded from `/api/posts` on every mount, so caching them in localStorage only risks serving stale data


Close #198 