### PR TITLE
feat: enhance API request handling with JSON body parsing and add uni…

### DIFF
--- a/app/app/api/analytics/events/route.ts
+++ b/app/app/api/analytics/events/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { apiSuccess, apiError } from "@/lib/api-response";
+import { readJsonBody } from "@/lib/parse-json-body";
 
 const VALID_EVENTS = [
   "page_view",
@@ -13,14 +14,15 @@ const VALID_EVENTS = [
 
 export async function POST(request: NextRequest) {
   try {
-    let body: any;
-    try {
-      body = await request.json();
-    } catch {
-      return apiError("Invalid or missing JSON body", 400);
-    }
+    const parsed = await readJsonBody<Record<string, unknown>>(request);
+    if (!parsed.ok) return parsed.response;
 
-    const { eventType, eventData, pageUrl } = body ?? {};
+    const body = parsed.data ?? {};
+    const { eventType, eventData, pageUrl } = body as {
+      eventType?: unknown;
+      eventData?: unknown;
+      pageUrl?: unknown;
+    };
 
     if (typeof eventType !== "string" || !VALID_EVENTS.includes(eventType as any)) {
       return apiError("Invalid event type", 400);

--- a/app/app/api/posts/[id]/entries/route.ts
+++ b/app/app/api/posts/[id]/entries/route.ts
@@ -4,6 +4,7 @@ import { awardXp, XP_REWARDS } from '@/lib/xp';
 import { NextRequest } from 'next/server';
 import { getCurrentUser } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { readJsonBody } from '@/lib/parse-json-body';
 
 /**
  * POST /api/posts/[id]/entries
@@ -18,8 +19,10 @@ export async function POST (
     if (!user) return apiError('Unauthorized', 401);
 
     const { id: postId } = await params;
-    const body = await request.json();
-    const { content, proofUrl } = body;
+    const raw = await readJsonBody<Record<string, unknown>>(request);
+    if (!raw.ok) return raw.response;
+    const body = raw.data;
+    const { content, proofUrl } = body as { content?: unknown; proofUrl?: unknown };
 
     // Validate content
     if (!content || typeof content !== 'string') {

--- a/app/app/api/posts/[id]/route.ts
+++ b/app/app/api/posts/[id]/route.ts
@@ -3,6 +3,7 @@ import { apiError, apiSuccess } from "@/lib/api-response";
 import { NextRequest } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { readJsonBody } from "@/lib/parse-json-body";
 
 const GET = async (
     request: NextRequest,
@@ -72,7 +73,9 @@ const PATCH = async (
         if (!user) return apiError('Unauthorized', 401);
 
         const { id } = await params;
-        const body = await request.json();
+        const raw = await readJsonBody<Record<string, unknown>>(request);
+        if (!raw.ok) return raw.response;
+        const body = raw.data;
 
         const post = await prisma.post.findUnique({
             where: { id },

--- a/app/app/api/posts/[id]/select-winners/route.ts
+++ b/app/app/api/posts/[id]/select-winners/route.ts
@@ -2,6 +2,7 @@ import { apiError, apiSuccess } from "@/lib/api-response";
 import { NextRequest } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { readJsonBody } from "@/lib/parse-json-body";
 
 export const POST = async (
     request: NextRequest,
@@ -12,7 +13,9 @@ export const POST = async (
         if (!user) return apiError('Unauthorized', 401);
 
         const { id } = await params;
-        const body = await request.json();
+        const raw = await readJsonBody<Record<string, unknown>>(request);
+        if (!raw.ok) return raw.response;
+        const body = raw.data;
 
         const post = await prisma.post.findUnique({
             where: { id },

--- a/app/app/api/posts/route.ts
+++ b/app/app/api/posts/route.ts
@@ -1,23 +1,30 @@
 import { apiError, apiSuccess } from '@/lib/api-response';
 import { awardXp, XP_REWARDS } from '@/lib/xp';
 
+import { Prisma } from '@prisma/client';
 import { NextRequest } from 'next/server';
 import { getCurrentUser } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { readJsonBody } from '@/lib/parse-json-body';
+import { sanitizePostSlug } from '@/lib/post-slug';
 
 const POST = async (request: NextRequest) => {
   try {
     const user = await getCurrentUser(request);
     if (!user) return apiError('Unauthorized', 401);
 
-    let body;
-    try {
-      body = await request.json();
-    } catch {
-      return apiError('Invalid or missing JSON body', 400);
-    }
+    const parsed = await readJsonBody<Record<string, unknown>>(request);
+    if (!parsed.ok) return parsed.response;
 
-    const { title, description, type, winnerCount, endsAt, proofRequired } = body;
+    const body = parsed.data;
+    const { title, description, type, winnerCount, endsAt, proofRequired } = body as {
+      title?: string;
+      description?: string;
+      type?: string;
+      winnerCount?: unknown;
+      endsAt?: string;
+      proofRequired?: unknown;
+    };
 
     if (!title || title.length < 10 || title.length > 200) {
       return apiError('Title must be 10-200 characters', 400);
@@ -25,6 +32,16 @@ const POST = async (request: NextRequest) => {
 
     if (!description || description.length < 50) {
       return apiError('Description must be at least 50 characters', 400);
+    }
+
+    const slug = sanitizePostSlug(body.slug, title);
+
+    const existingSlug = await prisma.post.findUnique({
+      where: { slug },
+      select: { id: true },
+    });
+    if (existingSlug) {
+      return apiError('Slug already in use', 409);
     }
 
     const post = await prisma.$transaction(async (tx) => {
@@ -39,7 +56,7 @@ const POST = async (request: NextRequest) => {
           userId: user.id,
           type,
           title,
-          slug: body.slug || title.toLowerCase().replace(/\s+/g, '-').slice(0, 50),
+          slug,
           description,
           maxWinners: winnerCount ? Number(winnerCount) : null,
           postRequirementsId: requirements.id,
@@ -89,6 +106,12 @@ const POST = async (request: NextRequest) => {
 
     return apiSuccess(post, "Post created successfully", 201);
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      const target = error.meta?.target as string[] | undefined;
+      if (target?.includes('slug')) {
+        return apiError('Slug already in use', 409);
+      }
+    }
     return apiError('Failed to create post', 500);
   }
 }

--- a/app/app/api/users/[id]/route.ts
+++ b/app/app/api/users/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { getCurrentUser } from '@/lib/auth';
+import { readJsonBody } from '@/lib/parse-json-body';
 
 export async function GET(
   request: NextRequest,
@@ -54,7 +55,9 @@ export async function PATCH(
       return apiError('Can only update own profile', 403);
     }
 
-    const { name, username, bio, email } = await request.json();
+    const raw = await readJsonBody<Record<string, unknown>>(request);
+    if (!raw.ok) return raw.response;
+    const { name, username, bio, email } = raw.data;
 
     try {
       // --- Uniqueness checks ---

--- a/app/app/api/wallet/fund/route.ts
+++ b/app/app/api/wallet/fund/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { apiError, apiSuccess } from '@/lib/api-response';
 import { getCurrentUser } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { readJsonBody } from '@/lib/parse-json-body';
 
 const fundSchema = z.object({
     amount: z.number().positive('Amount must be greater than 0'),
@@ -15,8 +16,9 @@ export async function POST(request: NextRequest) {
         const currentUser = await getCurrentUser(request);
         if (!currentUser) return apiError('Unauthorized', 401);
 
-        const body = await request.json();
-        const parsed = fundSchema.safeParse(body);
+        const raw = await readJsonBody(request);
+        if (!raw.ok) return raw.response;
+        const parsed = fundSchema.safeParse(raw.data);
         if (!parsed.success) {
             return apiError(parsed.error.errors[0].message, 400);
         }

--- a/app/app/api/wallet/withdraw/route.ts
+++ b/app/app/api/wallet/withdraw/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { apiError, apiSuccess } from '@/lib/api-response';
 import { getCurrentUser } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { readJsonBody } from '@/lib/parse-json-body';
 
 const withdrawSchema = z.object({
     amount: z.number().positive('Amount must be greater than 0'),
@@ -15,8 +16,9 @@ export async function POST(request: NextRequest) {
         const currentUser = await getCurrentUser(request);
         if (!currentUser) return apiError('Unauthorized', 401);
 
-        const body = await request.json();
-        const parsed = withdrawSchema.safeParse(body);
+        const raw = await readJsonBody(request);
+        if (!raw.ok) return raw.response;
+        const parsed = withdrawSchema.safeParse(raw.data);
         if (!parsed.success) {
             return apiError(parsed.error.errors[0].message, 400);
         }

--- a/app/lib/parse-json-body.ts
+++ b/app/lib/parse-json-body.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from 'next/server';
+
+import { apiError } from '@/lib/api-response';
+
+/** Default cap for JSON request bodies on API routes (manual check; see also next.config serverActions.bodySizeLimit). */
+export const DEFAULT_JSON_BODY_MAX_BYTES = 512 * 1024;
+
+export type ReadJsonBodyResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; response: Response };
+
+function isJsonContentType(request: NextRequest): boolean {
+  const ct = request.headers.get('content-type');
+  if (!ct) return false;
+  const base = ct.split(';')[0]?.trim().toLowerCase();
+  return base === 'application/json';
+}
+
+/**
+ * Validates Content-Type, enforces a max body size, and parses JSON.
+ * Use instead of raw `request.json()` on write endpoints.
+ */
+export async function readJsonBody<T = unknown>(
+  request: NextRequest,
+  maxBytes: number = DEFAULT_JSON_BODY_MAX_BYTES,
+): Promise<ReadJsonBodyResult<T>> {
+  if (!isJsonContentType(request)) {
+    return {
+      ok: false,
+      response: apiError('Content-Type must be application/json', 415),
+    };
+  }
+
+  const contentLength = request.headers.get('content-length');
+  if (contentLength) {
+    const len = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(len) && len > maxBytes) {
+      return { ok: false, response: apiError('Payload too large', 413) };
+    }
+  }
+
+  let text: string;
+  try {
+    text = await request.text();
+  } catch {
+    return { ok: false, response: apiError('Invalid or missing body', 400) };
+  }
+
+  if (text.length > maxBytes) {
+    return { ok: false, response: apiError('Payload too large', 413) };
+  }
+
+  try {
+    const data = JSON.parse(text) as T;
+    return { ok: true, data };
+  } catch {
+    return { ok: false, response: apiError('Invalid JSON body', 400) };
+  }
+}

--- a/app/lib/post-slug.ts
+++ b/app/lib/post-slug.ts
@@ -1,0 +1,45 @@
+/** Max length for post slugs (must match DB and API validation). */
+export const POST_SLUG_MAX_LENGTH = 50;
+
+/**
+ * Produces a URL-safe slug: lowercase, [a-z0-9-] only, max {@link POST_SLUG_MAX_LENGTH} chars.
+ * Path segments like `../` are stripped; empty result falls back to the title-derived slug.
+ */
+export function sanitizePostSlug(
+  raw: unknown,
+  title: string,
+): string {
+  const fromTitle = (): string => {
+    const base = title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+    const s = base.slice(0, POST_SLUG_MAX_LENGTH);
+    return s.length > 0 ? s : 'post';
+  };
+
+  if (raw == null || raw === '') {
+    return fromTitle();
+  }
+
+  if (typeof raw !== 'string') {
+    return fromTitle();
+  }
+
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === '') {
+    return fromTitle();
+  }
+
+  const only = trimmed
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  if (only === '') {
+    return fromTitle();
+  }
+
+  return only.slice(0, POST_SLUG_MAX_LENGTH);
+}

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -2,5 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   transpilePackages: ["next-auth", "jose"],
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "512kb",
+    },
+  },
 };
-export default nextConfig
+export default nextConfig;

--- a/app/prisma/migrations/20260325120000_add_unique_constraint_on_post_slug/migration.sql
+++ b/app/prisma/migrations/20260325120000_add_unique_constraint_on_post_slug/migration.sql
@@ -1,0 +1,32 @@
+-- Normalize slugs to match app rules before adding uniqueness
+UPDATE "posts"
+SET "slug" = LEFT(
+  TRIM(BOTH '-' FROM REGEXP_REPLACE(REGEXP_REPLACE(LOWER(TRIM("slug")), '[^a-z0-9-]+', '-', 'g'), '-+', '-', 'g')),
+  50
+);
+
+UPDATE "posts"
+SET "slug" = 'post-' || SUBSTR(MD5("id"::TEXT), 1, 8)
+WHERE "slug" = '' OR "slug" IS NULL;
+
+-- Deduplicate: append id fragment for rows after the first per slug
+WITH "ranked" AS (
+  SELECT "id", "slug",
+    ROW_NUMBER() OVER (PARTITION BY "slug" ORDER BY "created_at") AS "rn"
+  FROM "posts"
+)
+UPDATE "posts" AS p
+SET "slug" = LEFT(
+  TRIM(BOTH '-' FROM REGEXP_REPLACE(REGEXP_REPLACE(LOWER(TRIM(
+    p."slug" || '-' || LEFT(REPLACE(p."id"::TEXT, '-', ''), 8)
+  )), '[^a-z0-9-]+', '-', 'g'), '-+', '-', 'g')),
+  50
+)
+FROM "ranked" AS r
+WHERE p."id" = r."id" AND r."rn" > 1;
+
+-- Align column type with Prisma @db.VarChar(50)
+ALTER TABLE "posts" ALTER COLUMN "slug" SET DATA TYPE VARCHAR(50);
+
+-- Unique constraint on slug
+CREATE UNIQUE INDEX "posts_slug_key" ON "posts"("slug");

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -267,7 +267,7 @@ model Post {
   id                String          @id @default(uuid())
   userId            String          @map("creator_id")
   type              PostType
-  slug              String
+  slug              String          @unique @db.VarChar(50)
   title             String          @db.VarChar(200)
   description       String?
   duration          Int?            @map("duration") // Duration in seconds for time-limited posts

--- a/app/tests/api/posts.test.ts
+++ b/app/tests/api/posts.test.ts
@@ -54,6 +54,7 @@ describe('Posts API', () => {
       // Mock prisma.post.findMany and count
       prisma.post.findMany = vi.fn().mockResolvedValue([]);
       prisma.post.count = vi.fn().mockResolvedValue(0);
+      prisma.post.findUnique = vi.fn().mockResolvedValue(null);
       // Mock prisma.post.create
       prisma.post.create = vi.fn().mockImplementation((args: any) => Promise.resolve({
         id: 'post_123',

--- a/app/tests/helpers/api.ts
+++ b/app/tests/helpers/api.ts
@@ -11,9 +11,14 @@ export function createMockRequest(
 ): NextRequest {
   const { method = 'GET', body, headers = {}, cookies = {} } = options || {};
 
+  const hdrs = new Headers(headers);
+  if (body !== undefined && !hdrs.has('Content-Type')) {
+    hdrs.set('Content-Type', 'application/json');
+  }
+
   const request = new NextRequest(url, {
     method,
-    headers: new Headers(headers),
+    headers: hdrs,
     body: body ? JSON.stringify(body) : undefined,
   });
 

--- a/app/tests/lib/post-slug.test.ts
+++ b/app/tests/lib/post-slug.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { POST_SLUG_MAX_LENGTH, sanitizePostSlug } from '@/lib/post-slug';
+
+describe('sanitizePostSlug', () => {
+  it('strips path-like segments and keeps safe characters', () => {
+    expect(sanitizePostSlug('../../admin', 'My Title Here')).toBe('admin');
+  });
+
+  it('falls back to title when slug becomes empty', () => {
+    expect(sanitizePostSlug('...', 'Hello World')).toBe('hello-world');
+  });
+
+  it('normalizes to lowercase and truncates', () => {
+    const long = 'a'.repeat(POST_SLUG_MAX_LENGTH + 20);
+    const out = sanitizePostSlug(long, 'x');
+    expect(out).toBe('a'.repeat(POST_SLUG_MAX_LENGTH));
+    expect(out.length).toBe(POST_SLUG_MAX_LENGTH);
+  });
+});


### PR DESCRIPTION
Closes #206

---

# Pull Request Template

## Description

This PR closes **#206** by hardening JSON write endpoints and securing post slugs (Content-Type and body size validation, slug sanitization, and a unique constraint on `Post.slug`).

**Summary of changes**

- Added `readJsonBody()` in `lib/parse-json-body.ts` to require `Content-Type: application/json`, enforce a default **512 KiB** body limit, and return consistent errors for invalid JSON.
- Replaced `request.json()` with `readJsonBody` on the affected **POST** and **PATCH** API routes (posts, analytics events, wallet fund/withdraw, post entries, select winners, post patch, user profile patch).
- Set `experimental.serverActions.bodySizeLimit: "512kb"` in `next.config.ts`.
- Added `sanitizePostSlug()` in `lib/post-slug.ts` (lowercase, `[a-z0-9-]` only, max **50** characters, safe fallback from title).
- Added **`@unique`** on **`Post.slug`** with `@db.VarChar(50)` and a migration to normalize/dedupe existing rows before the unique index; **409** + **P2002** handling for duplicate slugs.
- Updated tests (request helper `Content-Type`, `post.findUnique` mock, slug unit tests).

**Motivation**

Endpoints already caught malformed JSON, but there was no strict `Content-Type` check, no body size cap, and slugs were not fully sanitized or unique—this addresses those gaps.

---

## Checklist

- [ ] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have run `npx prisma generate` after schema changes
- [ ] I have run `npx prisma migrate dev` or `npx prisma migrate deploy` as appropriate

---

## Post-Merge Steps for Maintainers

**If this PR includes changes to the Prisma schema:**

1. Run the following command to apply the migration to your database:

   ```sh
   npx prisma migrate deploy
   ```

   or, for local development:

   ```sh
   npx prisma migrate dev
   ```

2. Ensure your CI pipeline runs the migration before tests (add this step if missing):

   ```yaml
   - name: Run Prisma Migrate
     run: npx prisma migrate deploy
   ```

3. Make sure the database user in CI has permission to run migrations.

---

If you have any questions, please comment on this PR.
