### PR TITLE
fix: initialize isMobile to undefined to prevent hydration mismatch

### DIFF
--- a/app/hooks/use-mobile.ts
+++ b/app/hooks/use-mobile.ts
@@ -3,20 +3,12 @@
 import { useState, useEffect } from "react"
 
 export function useMobile() {
-  const [isMobile, setIsMobile] = useState(false)
+  const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined)
 
   useEffect(() => {
-    const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < 768)
-    }
-
-    // Check on mount
+    const checkIsMobile = () => setIsMobile(window.innerWidth < 768)
     checkIsMobile()
-
-    // Add event listener
     window.addEventListener("resize", checkIsMobile)
-
-    // Cleanup
     return () => window.removeEventListener("resize", checkIsMobile)
   }, [])
 


### PR DESCRIPTION
Fixes a hydration mismatch in `app/hooks/use-mobile.ts`. The hook previously
initialized `isMobile` to `false`, causing the server to render the desktop
layout while the client immediately swapped to mobile on first paint  React
detected the mismatch and logged a hydration error with a visible layout flash.

Changed initial state to `undefined` so server and client agree until
`useEffect` fires and sets the real value from `window.innerWidth`.

Components consuming this hook should guard the `undefined` state:
if (isMobile === undefined) return null

Closes #246

---

## Checklist
- [ ] I have tested my changes locally
- [ ] I have updated documentation as needed
- [ ] I have run `npx prisma generate` after schema changes
- [ ] I have run `npx prisma migrate dev` or `npx prisma migrate deploy` as appropriate

---

## Post-Merge Steps for Maintainers
No Prisma schema changes in this PR. No migration steps required.
