### PR TITLE
feat: add Post category field and client-side image compression

### DIFF
--- a/app/app/api/posts/route.ts
+++ b/app/app/api/posts/route.ts
@@ -95,7 +95,7 @@ const POST = async (request: NextRequest) => {
 
     const body = parsed.data;
 
-    const { title, description, type, winnerCount, endsAt, proofRequired } =
+    const { title, description, type, winnerCount, endsAt, proofRequired, category } =
       body as {
         title?: string;
         description?: string;
@@ -103,6 +103,7 @@ const POST = async (request: NextRequest) => {
         winnerCount?: unknown;
         endsAt?: string;
         proofRequired?: unknown;
+        category?: string;
       };
 
     if (!title || title.length < 10 || title.length > 200) {
@@ -132,6 +133,7 @@ const POST = async (request: NextRequest) => {
           title,
           slug: uniqueSlug,
           description,
+          category: category as any ?? null,
           maxWinners: winnerCount ? Number(winnerCount) : null,
           postRequirementsId: requirements.id,
           endsAt: new Date(endsAt),

--- a/app/components/media-upload.tsx
+++ b/app/components/media-upload.tsx
@@ -5,24 +5,33 @@ import { useState, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Upload, X, ImageIcon, Video, FileText, Loader2 } from "lucide-react"
+import { Upload, X, ImageIcon, Video, FileText, Loader2, CheckCircle2 } from "lucide-react"
 import { toast } from "sonner"
 import type { PostMedia } from "@/lib/types"
 import { validateMedia } from "@/lib/media-utils"
 import { uploadFile } from "@/lib/storage"
+import { compressImage, generateThumbnail, formatFileSize } from "@/lib/image-compression"
 
 // ── Constants ─────────────────────────────────────────────────
-const MAX_IMAGE_SIZE = 10  * 1024 * 1024  // 10 MB
+const MAX_IMAGE_SIZE = 10  * 1024 * 1024  // 10 MB (before compression)
 const MAX_VIDEO_SIZE = 100 * 1024 * 1024  // 100 MB
 const ALLOWED_IMAGE  = ["image/jpeg", "image/png", "image/webp", "image/gif"]
 const ALLOWED_VIDEO  = ["video/mp4", "video/webm", "video/quicktime"]
 
 // ── Types ─────────────────────────────────────────────────────
 
+interface CompressionInfo {
+  originalSize: number
+  compressedSize: number
+  savedPercent: number
+}
+
 // Extends PostMedia with transient UI state that never leaves this component.
 interface ExtendedPostMedia extends PostMedia {
-  isUploading?: boolean
-  error?:       string
+  isUploading?:  boolean
+  isCompressing?: boolean
+  error?:        string
+  compressionInfo?: CompressionInfo
 }
 
 interface MediaUploadProps {
@@ -64,7 +73,6 @@ export function MediaUpload({
         continue
       }
 
-      // 2. Additional size checks using the constants
       const isImage = ALLOWED_IMAGE.includes(file.type)
       const isVideo = ALLOWED_VIDEO.includes(file.type)
       const maxSize = isVideo ? MAX_VIDEO_SIZE : MAX_IMAGE_SIZE
@@ -77,15 +85,16 @@ export function MediaUpload({
         continue
       }
 
-      // 3. Add placeholder so the grid updates immediately
       const tempId = `${Date.now()}-${file.name}`
 
+      // 2. Add compressing placeholder for images
       const placeholder: ExtendedPostMedia = {
-        id:          tempId,
-        type:        isImage ? "image" : "video",
-        url:         URL.createObjectURL(file),   // temporary preview
-        thumbnail:   isImage ? URL.createObjectURL(file) : undefined,
-        isUploading: true,
+        id:            tempId,
+        type:          isImage ? "image" : "video",
+        url:           URL.createObjectURL(file),
+        thumbnail:     isImage ? URL.createObjectURL(file) : undefined,
+        isUploading:   false,
+        isCompressing: isImage,
       }
 
       setMedia((prev) => {
@@ -94,10 +103,59 @@ export function MediaUpload({
         return updated
       })
 
+      // 3. Compress images before upload (Issue #64)
+      let fileToUpload = file
+      let compressionInfo: CompressionInfo | undefined
+
+      if (isImage) {
+        try {
+          const result = await compressImage(file)
+          const thumb  = await generateThumbnail(result.file)
+
+          fileToUpload   = result.file
+          compressionInfo = {
+            originalSize:    result.originalSize,
+            compressedSize:  result.compressedSize,
+            savedPercent:    result.savedPercent,
+          }
+
+          // Update preview to the compressed + thumbnail versions
+          setMedia((prev) =>
+            prev.map((item) =>
+              item.id === tempId
+                ? {
+                    ...item,
+                    url:           URL.createObjectURL(result.file),
+                    thumbnail:     thumb.dataUrl,
+                    isCompressing: false,
+                    isUploading:   true,
+                    compressionInfo,
+                  }
+                : item,
+            ),
+          )
+        } catch {
+          // Compression failed — proceed with original, clear compressing flag
+          setMedia((prev) =>
+            prev.map((item) =>
+              item.id === tempId
+                ? { ...item, isCompressing: false, isUploading: true }
+                : item,
+            ),
+          )
+        }
+      } else {
+        setMedia((prev) =>
+          prev.map((item) =>
+            item.id === tempId ? { ...item, isUploading: true } : item,
+          ),
+        )
+      }
+
       // 4. Real upload via /api/uploads (S3-backed)
       try {
         const form = new FormData()
-        form.append("file",   file)
+        form.append("file",   fileToUpload)
         form.append("folder", isVideo ? "videos" : "images")
 
         const res = await fetch("/api/uploads", { method: "POST", body: form })
@@ -107,22 +165,32 @@ export function MediaUpload({
           throw new Error(body.error ?? "Upload failed")
         }
 
-        const { url, key } = await res.json() as { url: string; key: string }
+        const { url } = await res.json() as { url: string; key: string }
 
-        // Replace placeholder with permanent CDN-backed item
         setMedia((prev) => {
           const updated = prev.map((item) =>
             item.id === tempId
-              ? { ...item, url, thumbnail: isImage ? url : undefined, isUploading: false }
+              ? {
+                  ...item,
+                  url,
+                  thumbnail:   isImage ? url : undefined,
+                  isUploading: false,
+                  compressionInfo: item.compressionInfo,
+                }
               : item,
           )
           onMediaChange(updated)
           return updated
         })
+
+        if (compressionInfo && compressionInfo.savedPercent > 0) {
+          toast.success("Image optimised", {
+            description: `Saved ${compressionInfo.savedPercent}% — ${formatFileSize(compressionInfo.originalSize)} → ${formatFileSize(compressionInfo.compressedSize)}`,
+          })
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : "Please try again."
         toast.error("Upload failed", { description: message })
-        // Remove the failed placeholder
         setMedia((prev) => {
           const updated = prev.filter((item) => item.id !== tempId)
           onMediaChange(updated)
@@ -160,6 +228,15 @@ export function MediaUpload({
     return <FileText className="w-4 h-4" />
   }
 
+  const getStatusLabel = (item: ExtendedPostMedia) => {
+    if (item.isCompressing) return "Optimising…"
+    if (item.isUploading)   return "Uploading…"
+    return item.type
+  }
+
+  const isProcessing = (item: ExtendedPostMedia) =>
+    item.isCompressing || item.isUploading
+
   // ── Render ─────────────────────────────────────────────────
 
   return (
@@ -182,7 +259,7 @@ export function MediaUpload({
             Drag and drop media files here, or click to browse
           </p>
           <p className="text-xs text-gray-500">
-            Images up to 10 MB · Videos up to 100 MB · Max {maxFiles} files
+            Images auto-optimised to &lt;500 KB · Videos up to 100 MB · Max {maxFiles} files
           </p>
           <Button
             variant="outline"
@@ -217,25 +294,27 @@ export function MediaUpload({
               <Card key={item.id} className="relative group overflow-hidden">
                 <CardContent className="p-2">
                   <div className="relative aspect-video bg-gray-100 dark:bg-gray-800 rounded overflow-hidden flex items-center justify-center">
-                    {/* Upload overlay */}
-                    {item.isUploading && (
+                    {/* Processing overlay */}
+                    {isProcessing(item) && (
                       <div className="absolute inset-0 z-10 bg-black/40 flex flex-col items-center justify-center text-white p-2">
                         <Loader2 className="w-6 h-6 animate-spin mb-1" />
-                        <span className="text-[10px] font-medium">Uploading…</span>
+                        <span className="text-[10px] font-medium">
+                          {item.isCompressing ? "Optimising…" : "Uploading…"}
+                        </span>
                       </div>
                     )}
 
                     {item.type === "image" ? (
                       <img
-                        src={item.url || "/placeholder.svg"}
+                        src={item.thumbnail ?? item.url ?? "/placeholder.svg"}
                         alt="Upload preview"
                         className={`w-full h-full object-cover transition-opacity ${
-                          item.isUploading ? "opacity-50" : "opacity-100"
+                          isProcessing(item) ? "opacity-50" : "opacity-100"
                         }`}
                       />
                     ) : (
                       <div className={`w-full h-full flex items-center justify-center ${
-                        item.isUploading ? "opacity-50" : "opacity-100"
+                        isProcessing(item) ? "opacity-50" : "opacity-100"
                       }`}>
                         <Video className="w-8 h-8 text-gray-400" />
                       </div>
@@ -243,26 +322,34 @@ export function MediaUpload({
                   </div>
 
                   <div className="flex items-center justify-between mt-2">
-                    <Badge variant="outline" className="text-[10px] h-5 px-1.5">
-                      {item.isUploading
+                    <Badge variant="outline" className="text-[10px] h-5 px-1.5 gap-1">
+                      {isProcessing(item)
                         ? <Loader2 className="w-3 h-3 animate-spin" />
-                        : getFileIcon(item.type)
+                        : item.compressionInfo
+                          ? <CheckCircle2 className="w-3 h-3 text-green-500" />
+                          : getFileIcon(item.type)
                       }
-                      <span className="ml-1 capitalize">
-                        {item.isUploading ? "Uploading…" : item.type}
-                      </span>
+                      <span className="capitalize">{getStatusLabel(item)}</span>
                     </Badge>
+
                     <Button
                       variant="ghost"
                       size="sm"
                       type="button"
-                      disabled={item.isUploading}
+                      disabled={isProcessing(item)}
                       onClick={(e) => { e.stopPropagation(); removeMedia(item.id) }}
                       className="h-6 w-6 p-0 hover:bg-red-50 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
                     >
                       <X className="w-3 h-3" />
                     </Button>
                   </div>
+
+                  {/* Compression info badge */}
+                  {item.compressionInfo && item.compressionInfo.savedPercent > 0 && (
+                    <p className="text-[9px] text-green-600 dark:text-green-400 mt-0.5 leading-tight">
+                      {formatFileSize(item.compressionInfo.originalSize)} → {formatFileSize(item.compressionInfo.compressedSize)} (−{item.compressionInfo.savedPercent}%)
+                    </p>
+                  )}
                 </CardContent>
               </Card>
             ))}

--- a/app/lib/image-compression.ts
+++ b/app/lib/image-compression.ts
@@ -1,0 +1,100 @@
+import imageCompression from "browser-image-compression";
+
+export interface CompressionResult {
+  file: File;
+  originalSize: number;
+  compressedSize: number;
+  savedBytes: number;
+  savedPercent: number;
+}
+
+export interface ThumbnailResult {
+  file: File;
+  dataUrl: string;
+}
+
+const MAX_SIZE_MB = 0.5;
+const MAX_DIMENSION = 1200;
+const THUMB_DIMENSION = 300;
+const QUALITY = 0.82;
+
+function supportsWebP(): boolean {
+  if (typeof document === "undefined") return false;
+  const canvas = document.createElement("canvas");
+  canvas.width = 1;
+  canvas.height = 1;
+  return canvas.toDataURL("image/webp").startsWith("data:image/webp");
+}
+
+/**
+ * Compress an image file to <500 KB with max 1200×1200 dimensions.
+ * Converts to WebP when the browser supports it.
+ */
+export async function compressImage(file: File): Promise<CompressionResult> {
+  const originalSize = file.size;
+
+  const outputType = supportsWebP() ? "image/webp" : "image/jpeg";
+
+  const options = {
+    maxSizeMB: MAX_SIZE_MB,
+    maxWidthOrHeight: MAX_DIMENSION,
+    useWebWorker: true,
+    fileType: outputType,
+    initialQuality: QUALITY,
+    preserveExif: false,
+  };
+
+  let compressed: File;
+  try {
+    compressed = await imageCompression(file, options);
+  } catch {
+    // Return the original on failure so uploads never silently break.
+    compressed = file;
+  }
+
+  const compressedSize = compressed.size;
+  const savedBytes = originalSize - compressedSize;
+
+  return {
+    file: compressed,
+    originalSize,
+    compressedSize,
+    savedBytes,
+    savedPercent: originalSize > 0 ? Math.round((savedBytes / originalSize) * 100) : 0,
+  };
+}
+
+/**
+ * Generate a 300×300 thumbnail from an image file.
+ * Returns both a File object and a data URL for immediate preview.
+ */
+export async function generateThumbnail(file: File): Promise<ThumbnailResult> {
+  const options = {
+    maxSizeMB: 0.1,
+    maxWidthOrHeight: THUMB_DIMENSION,
+    useWebWorker: true,
+    fileType: supportsWebP() ? "image/webp" : "image/jpeg",
+    initialQuality: 0.75,
+    preserveExif: false,
+  };
+
+  let thumbFile: File;
+  try {
+    thumbFile = await imageCompression(file, options);
+  } catch {
+    thumbFile = file;
+  }
+
+  const dataUrl = await imageCompression.getDataUrlFromFile(thumbFile);
+
+  return { file: thumbFile, dataUrl };
+}
+
+/**
+ * Human-readable file size string, e.g. "1.2 MB" or "450 KB".
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
+    "browser-image-compression": "^2.0.2",
     "@aws-sdk/client-s3": "^3.1018.0",
     "@hookform/resolvers": "^3.10.0",
     "@prisma/adapter-pg": "^7.2.0",

--- a/app/prisma/migrations/20260423000000_add_post_category/migration.sql
+++ b/app/prisma/migrations/20260423000000_add_post_category/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "PostCategory" AS ENUM (
+  'electronics',
+  'clothing',
+  'books',
+  'furniture',
+  'toys',
+  'food',
+  'sports',
+  'beauty',
+  'automotive',
+  'other'
+);
+
+-- AlterTable
+ALTER TABLE "posts" ADD COLUMN "category" "PostCategory";
+
+-- CreateIndex
+CREATE INDEX "posts_category_idx" ON "posts"("category");

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -43,6 +43,23 @@ enum PostType {
   request
 }
 
+/**
+ * Predefined categories for posts (Issue #204).
+ * Keeps category values consistent across the platform.
+ */
+enum PostCategory {
+  electronics
+  clothing
+  books
+  furniture
+  toys
+  food
+  sports
+  beauty
+  automotive
+  other
+}
+
 enum SelectionMethod {
   random
   merit_based
@@ -271,6 +288,7 @@ model Post {
   title             String          @db.VarChar(200)
   description       String?
   duration          Int?            @map("duration") // Duration in seconds for time-limited posts
+  category          PostCategory?   @map("category")
   helpType          HelpType?       @map("help_type")
   urgency           Urgency?        @map("urgency")
   status            PostStatus      @default(open)
@@ -298,6 +316,7 @@ model Post {
 
   @@index([userId])
   @@index([status])
+  @@index([category])
   @@index([createdAt(sort: Desc)])
   @@map("posts")
 }


### PR DESCRIPTION
Closes #204
Closes #64

## What changed

### #204 — Post `category` field
- `PostCategory` enum in `schema.prisma`: `electronics`, `clothing`, `books`, `furniture`, `toys`, `food`, `sports`, `beauty`, `automotive`, `other`
- `category PostCategory?` on `Post` model + `@@index([category])`
- Migration: `20260423000000_add_post_category`
- `POST /api/posts` now accepts and stores `category`
- `GET /api/posts?category=electronics` now filters against the real DB column

### #64 — Client-side image optimisation
- New `lib/image-compression.ts`: `compressImage()` (<500 KB, max 1200×1200, WebP/JPEG), `generateThumbnail()` (300×300), `formatFileSize()`
- `MediaUpload` updated: compress → upload pipeline, "Optimising…" overlay, per-card savings label, toast with before/after sizes, silent fallback on error

## How to test
- Create a post with a category — verify stored and returned in GET
- Filter: `GET /api/posts?category=electronics`
- Upload a large image — observe compression overlay and savings badge