### PR TITLE
Add post expiry automation based on endsAt field

### DIFF
--- a/app/app/api/cron/expire-posts/route.ts
+++ b/app/app/api/cron/expire-posts/route.ts
@@ -1,0 +1,66 @@
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { createNotification } from "@/lib/notifications";
+import { prisma } from "@/lib/prisma";
+import { NextRequest } from "next/server";
+
+function isAuthorizedCron(request: NextRequest): boolean {
+  if (request.headers.get("x-vercel-cron") === "1") {
+    return true;
+  }
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return false;
+  }
+  const auth = request.headers.get("authorization");
+  return auth === `Bearer ${secret}`;
+}
+
+/**
+ * Hourly job: mark open giveaways whose deadline has passed as expired,
+ * and notify creators.
+ */
+const GET = async (request: NextRequest) => {
+  if (!isAuthorizedCron(request)) {
+    return apiError("Unauthorized", 401);
+  }
+
+  const now = new Date();
+
+  const toExpire = await prisma.post.findMany({
+    where: {
+      status: "open",
+      endsAt: { lt: now },
+    },
+    select: { id: true, userId: true, title: true },
+  });
+
+  if (toExpire.length === 0) {
+    return apiSuccess({ expired: 0, ids: [] as string[] });
+  }
+
+  await prisma.post.updateMany({
+    where: {
+      status: "open",
+      endsAt: { lt: now },
+    },
+    data: { status: "expired" },
+  });
+
+  await Promise.all(
+    toExpire.map((post) =>
+      createNotification({
+        userId: post.userId,
+        type: "post_closed",
+        message: `Your giveaway "${post.title}" has ended (deadline passed).`,
+        link: `/post/${post.id}`,
+      }).catch(() => undefined),
+    ),
+  );
+
+  return apiSuccess({
+    expired: toExpire.length,
+    ids: toExpire.map((p) => p.id),
+  });
+};
+
+export { GET };

--- a/app/app/api/posts/route.ts
+++ b/app/app/api/posts/route.ts
@@ -201,10 +201,15 @@ const GET = async (request: NextRequest) => {
     const q = searchParams.get("q");
     const category = searchParams.get("category");
     const sort = searchParams.get("sort");
+    const filter = searchParams.get("filter");
     const page = parseInt(searchParams.get("page") || "1");
     const limit = parseInt(searchParams.get("limit") || "10");
 
     const where: any = {};
+
+    if (filter === "active") {
+      where.endsAt = { gt: new Date() };
+    }
 
     if (q) {
       where.OR = [

--- a/app/app/post/[postId]/page.tsx
+++ b/app/app/post/[postId]/page.tsx
@@ -7,7 +7,6 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronUp,
-  Clock,
   DollarSign,
   Flame,
   Gift,
@@ -24,15 +23,16 @@ import { Button } from "@/components/ui/button";
 import { CommentsSection } from "@/components/comments-section";
 import { ContributionForm } from "@/components/contribution-form";
 import { EntryForm } from "@/components/entry-form";
+import { GiveawayCountdown } from "@/components/giveaway-countdown";
 import Link from "next/link";
 import { Progress } from "@/components/ui/progress";
 import { UserRankBadge } from "@/components/user-rank-badge";
 import { useAppContext } from "@/contexts/app-context";
-import { useEffect, useState } from "react";
+import { mapApiPostToClientPost } from "@/lib/map-api-post";
+import { useCallback, useEffect, useState } from "react";
 
 export default function PostPage() {
-  const { user, burnPost } = useAppContext();
-  const [post, setPost] = useState<any>(null);
+  const { user, burnPost, posts, refreshPostDetail } = useAppContext();
   const params = useParams();
   const postId = params.postId as string;
   const contextPost = posts.find((p) => p.id === postId);
@@ -47,79 +47,65 @@ export default function PostPage() {
   const [showContributionForm, setShowContributionForm] = useState(false);
 
   const router = useRouter();
-  const normalizeApiPost = (apiPost: any) => {
-    if (!apiPost) return null;
 
-    const normalizedType = apiPost.type;
-    const normalizedStatus =
-      apiPost.status === "open" || apiPost.status === "in_progress"
-        ? "active"
-        : apiPost.status;
-    const fallbackUsername =
-      apiPost.user?.name?.toLowerCase()?.replace(/\s+/g, "") || "user";
+  const reloadPostFromApi = useCallback(async () => {
+    setIsLoadingPost(true);
+    try {
+      const response = await fetch(`/api/posts/${postId}`, {
+        cache: "no-store",
+      });
 
-    return {
-      ...apiPost,
-      type: normalizedType,
-      status: normalizedStatus,
-      createdAt: apiPost.createdAt ? new Date(apiPost.createdAt) : new Date(),
-      updatedAt: apiPost.updatedAt ? new Date(apiPost.updatedAt) : new Date(),
-      endDate: apiPost.endsAt ? new Date(apiPost.endsAt) : undefined,
-      burnCount: apiPost.burnCount ?? 0,
-      shareCount: apiPost.shareCount ?? 0,
-      commentCount: apiPost.commentCount ?? 0,
-      likesCount: apiPost.likesCount ?? apiPost._count?.interactions ?? 0,
-      entriesCount: apiPost.entriesCount ?? apiPost._count?.entries ?? 0,
-      author: {
-        id: apiPost.user?.id ?? apiPost.userId,
-        name: apiPost.user?.name ?? "Unknown User",
-        username: apiPost.user?.username ?? fallbackUsername,
-        avatarUrl: apiPost.user?.avatarUrl,
-        rank: apiPost.user?.rank,
-      },
-    };
-  };
-
-  useEffect(() => {
-    let ignore = false;
-
-    const loadPost = async () => {
-      if (contextPost) {
+      if (!response.ok) {
         setFetchedPost(null);
-        setIsLoadingPost(false);
         return;
       }
 
-      setIsLoadingPost(true);
+      const result = await response.json();
+      setFetchedPost(
+        mapApiPostToClientPost(result?.data as Record<string, unknown>),
+      );
+    } catch {
+      setFetchedPost(null);
+    } finally {
+      setIsLoadingPost(false);
+    }
+  }, [postId]);
 
+  useEffect(() => {
+    if (contextPost) {
+      setFetchedPost(null);
+      setIsLoadingPost(false);
+      return;
+    }
+
+    let ignore = false;
+
+    const run = async () => {
+      setIsLoadingPost(true);
       try {
         const response = await fetch(`/api/posts/${postId}`, {
           cache: "no-store",
         });
 
         if (!response.ok) {
-          if (!ignore) {
-            setFetchedPost(null);
-          }
+          if (!ignore) setFetchedPost(null);
           return;
         }
 
         const result = await response.json();
         if (!ignore) {
-          setFetchedPost(normalizeApiPost(result?.data));
+          setFetchedPost(
+            mapApiPostToClientPost(result?.data as Record<string, unknown>),
+          );
         }
-      } catch (error) {
-        if (!ignore) {
-          setFetchedPost(null);
-        }
+      } catch {
+        if (!ignore) setFetchedPost(null);
       } finally {
-        if (!ignore) {
-          setIsLoadingPost(false);
-        }
+        if (!ignore) setIsLoadingPost(false);
       }
     };
 
-    loadPost();
+    void run();
 
     return () => {
       ignore = true;
@@ -142,7 +128,8 @@ export default function PostPage() {
               body: JSON.stringify({ method, winnerIds })
           });
           if (res.ok) {
-              loadPost();
+              await refreshPostDetail(post.id);
+              if (!contextPost) await reloadPostFromApi();
           } else {
              const errorData = await res.json();
              alert(errorData.error || 'Failed to select winners');
@@ -418,10 +405,7 @@ export default function PostPage() {
                         </span>
                       </div>
                       {post.endDate && (
-                        <div className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
-                          <Clock className="w-4 h-4" />
-                          Ends {post.endDate.toLocaleDateString()}
-                        </div>
+                        <GiveawayCountdown endsAt={post.endDate} />
                       )}
                     </div>
 

--- a/app/components/create-giveaway-modal.tsx
+++ b/app/components/create-giveaway-modal.tsx
@@ -93,14 +93,17 @@ const response = await fetch("/api/posts", {
           type: "giveaway",
           title: formData.title,
           description: formData.description,
-          status: "active",
           prizeAmount: Number.parseFloat(formData.prizeAmount),
           currency: formData.currency,
           winnerCount: Number.parseInt(formData.winnerCount),
           selectionType: formData.selectionType,
           entryRequirements: requirements,
           proofRequired: formData.proofRequired,
-          endDate: formData.endDate ? new Date(formData.endDate) : undefined,
+          endsAt: (
+            formData.endDate
+              ? new Date(formData.endDate)
+              : new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+          ).toISOString(),
           media: media.length > 0 ? media : undefined,
         }),
       });

--- a/app/components/giveaway-countdown.tsx
+++ b/app/components/giveaway-countdown.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Clock } from "lucide-react";
+import { useEffect, useState } from "react";
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return "0s";
+  const s = Math.floor(ms / 1000);
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0 || d > 0) parts.push(`${h}h`);
+  if (m > 0 || h > 0 || d > 0) parts.push(`${m}m`);
+  parts.push(`${sec}s`);
+  return parts.join(" ");
+}
+
+type GiveawayCountdownProps = {
+  endsAt: Date;
+  className?: string;
+  showIcon?: boolean;
+};
+
+export function GiveawayCountdown({
+  endsAt,
+  className = "",
+  showIcon = true,
+}: GiveawayCountdownProps) {
+  const [label, setLabel] = useState(() => {
+    const diff = endsAt.getTime() - Date.now();
+    return diff <= 0 ? "Ended" : formatRemaining(diff);
+  });
+
+  useEffect(() => {
+    const tick = () => {
+      const diff = endsAt.getTime() - Date.now();
+      setLabel(diff <= 0 ? "Ended" : formatRemaining(diff));
+    };
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [endsAt]);
+
+  const ended = endsAt.getTime() <= Date.now();
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 text-sm font-medium tabular-nums ${
+        ended
+          ? "text-gray-500 dark:text-gray-400"
+          : "text-amber-700 dark:text-amber-400"
+      } ${className}`}
+    >
+      {showIcon && <Clock className="w-4 h-4 shrink-0" />}
+      <span>{ended ? "Ended" : `${label} left`}</span>
+    </div>
+  );
+}

--- a/app/components/post-card.tsx
+++ b/app/components/post-card.tsx
@@ -5,7 +5,6 @@ import {
   Calendar,
   ChevronDown,
   ChevronUp,
-  Clock,
   DollarSign,
   Flame,
   Gift,
@@ -21,6 +20,7 @@ import { Button } from '@/components/ui/button';
 import { CommentsSection } from '@/components/comments-section';
 import { ContributionForm } from '@/components/contribution-form';
 import { EntryForm } from '@/components/entry-form';
+import { GiveawayCountdown } from '@/components/giveaway-countdown';
 import Link from 'next/link';
 import type { Post } from '@/lib/types';
 import { Progress } from '@/components/ui/progress';
@@ -124,6 +124,14 @@ export function PostCard({ post }: PostCardProps) {
         return 'bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700';
     }
   };
+
+  const giveawayDeadline =
+    post.type === 'giveaway' && post.endDate ? post.endDate : null;
+  const giveawayStillOpen =
+    post.type === 'giveaway' &&
+    (post.status === 'active' || post.status === 'open') &&
+    giveawayDeadline &&
+    giveawayDeadline.getTime() > Date.now();
 
   const getProgressPercentage = () => {
     if (
@@ -293,11 +301,8 @@ export function PostCard({ post }: PostCardProps) {
                     Prize: {post.prizeAmount} {post.currency}
                   </span>
                 </div>
-                {post.endDate && (
-                  <div className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
-                    <Clock className="w-4 h-4" />
-                    Ends {post.endDate.toLocaleDateString()}
-                  </div>
+                {giveawayDeadline && (
+                  <GiveawayCountdown endsAt={giveawayDeadline} />
                 )}
               </div>
 
@@ -317,7 +322,7 @@ export function PostCard({ post }: PostCardProps) {
                 </div>
               )}
 
-              {post.status === 'active' && (
+              {giveawayStillOpen && (
                 <Button
                   onClick={(e) => {
                     handleInteractiveClick(e);

--- a/app/components/timeline-feed.tsx
+++ b/app/components/timeline-feed.tsx
@@ -10,6 +10,9 @@ import { CreateRequestModal } from "@/components/create-request-modal";
 import { GuestBanner } from "@/components/guest-banner";
 import { PostCard } from "@/components/post-card";
 import { useAppContext } from "@/contexts/app-context";
+import { mapApiPostToClientPost } from "@/lib/map-api-post";
+import type { Post } from "@/lib/types";
+import { useEffect, useState } from "react";
 
 export function TimelineFeed() {
   const {
@@ -23,6 +26,37 @@ export function TimelineFeed() {
     setShowRequestModal,
   } = useAppContext(); // Use context methods instead of dispatch
 
+  const [deadlineActivePosts, setDeadlineActivePosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadDeadlineActive = async () => {
+      try {
+        const res = await fetch("/api/posts?filter=active&limit=100", {
+          cache: "no-store",
+        });
+        if (!res.ok) return;
+        const json = await res.json();
+        const rawList = Array.isArray(json.data)
+          ? json.data
+          : json.data?.posts ?? [];
+        const mapped = rawList
+          .map((p: Record<string, unknown>) => mapApiPostToClientPost(p))
+          .filter(Boolean) as Post[];
+        if (!cancelled) setDeadlineActivePosts(mapped);
+      } catch {
+        if (!cancelled) setDeadlineActivePosts([]);
+      }
+    };
+
+    loadDeadlineActive();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [posts]);
+
   const handleCreatePost = (type: "giveaway" | "request") => {
     if (type === "giveaway") {
       setShowGiveawayModal(true); // Use context method
@@ -34,7 +68,6 @@ export function TimelineFeed() {
 
   const giveaways = posts.filter((post) => post.type === "giveaway");
   const helpRequests = posts.filter((post) => post.type === "request");
-  const activePosts = posts.filter((post) => post.status === "active");
 
   return (
     <div className="space-y-6">
@@ -57,7 +90,7 @@ export function TimelineFeed() {
             Help Requests ({helpRequests.length})
           </TabsTrigger>
           <TabsTrigger value="active" className="flex items-center gap-2">
-            Active ({activePosts.length})
+            Active ({deadlineActivePosts.length})
           </TabsTrigger>
         </TabsList>
 
@@ -112,8 +145,8 @@ export function TimelineFeed() {
         </TabsContent>
 
         <TabsContent value="active" className="space-y-6">
-          {activePosts.length > 0 ? (
-            activePosts.map((post) => <PostCard key={post.id} post={post} />)
+          {deadlineActivePosts.length > 0 ? (
+            deadlineActivePosts.map((post) => <PostCard key={post.id} post={post} />)
           ) : (
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm">
               <CardContent className="p-8 text-center">

--- a/app/contexts/app-context.tsx
+++ b/app/contexts/app-context.tsx
@@ -16,6 +16,7 @@ import {
   useReducer,
   useState,
 } from 'react';
+import { mapApiPostToClientPost } from '@/lib/map-api-post';
 import { deserializeState, serializeState } from '@/lib/utils';
 import { signIn, signOut } from 'next-auth/react';
 
@@ -197,11 +198,15 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         }
 
         const postData = await postRes.json();
+        const rawList = Array.isArray(postData.data)
+          ? postData.data
+          : postData.data?.posts ?? [];
+        const mapped = rawList
+          .map((p: Record<string, unknown>) => mapApiPostToClientPost(p))
+          .filter(Boolean) as Post[];
         dispatch({
           type: 'SET_POSTS',
-          payload: Array.isArray(postData.data)
-            ? postData.data
-            : postData.data?.posts ?? [],
+          payload: mapped,
         });
       } catch (error) {
         console.error('Failed to load data from API', error);
@@ -230,9 +235,13 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         const res = await fetch('/api/posts', { cache: 'no-store' });
         if (!res.ok) return;
         const data = await res.json();
+        const rawList = Array.isArray(data.data) ? data.data : data.data?.posts ?? [];
+        const mapped = rawList
+          .map((p: Record<string, unknown>) => mapApiPostToClientPost(p))
+          .filter(Boolean) as Post[];
         dispatch({
           type: 'SET_POSTS',
-          payload: Array.isArray(data.data) ? data.data : data.data?.posts ?? [],
+          payload: mapped,
         });
       } catch {
         // silently ignore refresh failures
@@ -243,7 +252,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         const res = await fetch(`/api/posts/${postId}`, { cache: 'no-store' });
         if (!res.ok) return;
         const data = await res.json();
-        const post = data.data ?? data.post ?? null;
+        const raw = data.data ?? data.post ?? null;
+        const post = raw
+          ? mapApiPostToClientPost(raw as Record<string, unknown>)
+          : null;
         if (post) {
           dispatch({ type: 'UPDATE_POST', payload: { id: postId, updates: post } });
         }

--- a/app/lib/map-api-post.ts
+++ b/app/lib/map-api-post.ts
@@ -1,0 +1,48 @@
+import type { Post, PostStatus } from "@/lib/types";
+
+/**
+ * Maps a post object from the API (Prisma shape) to the client `Post` shape.
+ */
+export function mapApiPostToClientPost(apiPost: Record<string, unknown> | null | undefined): Post | null {
+  if (!apiPost || typeof apiPost !== "object") return null;
+
+  const rawStatus = apiPost.status as string | undefined;
+  const normalizedStatus: PostStatus =
+    rawStatus === "open" || rawStatus === "in_progress"
+      ? "active"
+      : (rawStatus as PostStatus) ?? "active";
+
+  const user = apiPost.user as Record<string, unknown> | undefined;
+  const fallbackUsername =
+    typeof user?.name === "string"
+      ? user.name.toLowerCase().replace(/\s+/g, "")
+      : "user";
+
+  const _count = apiPost._count as Record<string, number> | undefined;
+
+  return {
+    ...apiPost,
+    type: apiPost.type as Post["type"],
+    userId: (apiPost.userId as string) ?? (user?.id as string) ?? "",
+    status: normalizedStatus,
+    createdAt: apiPost.createdAt ? new Date(apiPost.createdAt as string) : new Date(),
+    updatedAt: apiPost.updatedAt ? new Date(apiPost.updatedAt as string) : new Date(),
+    endDate: apiPost.endsAt ? new Date(apiPost.endsAt as string) : undefined,
+    burnCount: (apiPost.burnCount as number) ?? 0,
+    shareCount: (apiPost.shareCount as number) ?? 0,
+    commentCount: (apiPost.commentCount as number) ?? 0,
+    likesCount:
+      (apiPost.likesCount as number) ??
+      (typeof _count?.interactions === "number" ? _count.interactions : 0),
+    entriesCount:
+      (apiPost.entriesCount as number) ??
+      (typeof _count?.entries === "number" ? _count.entries : 0),
+    author: {
+      id: (user?.id as string) ?? (apiPost.userId as string) ?? "",
+      name: (user?.name as string) ?? "Unknown User",
+      username: (user?.username as string) ?? fallbackUsername,
+      avatarUrl: user?.avatarUrl as string | undefined,
+      rank: user?.rank,
+    },
+  } as Post;
+}

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -76,7 +76,13 @@ export interface PostMedia {
   thumbnail?: string
 }
 
-export type PostStatus = "active" | "completed" | "cancelled" | "expired"
+export type PostStatus =
+  | "active"
+  | "open"
+  | "in_progress"
+  | "completed"
+  | "cancelled"
+  | "expired"
 
 export interface Entry {
   id: string

--- a/app/tests/api/cron-expire-posts.test.ts
+++ b/app/tests/api/cron-expire-posts.test.ts
@@ -1,0 +1,72 @@
+import { GET } from "@/app/api/cron/expire-posts/route";
+import * as notifications from "@/lib/notifications";
+import { prisma } from "@/lib/prisma";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockRequest, parseResponse } from "../helpers/api";
+
+describe("GET /api/cron/expire-posts", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.CRON_SECRET;
+    vi.spyOn(notifications, "createNotification").mockResolvedValue({
+      id: "n1",
+    } as Awaited<ReturnType<typeof notifications.createNotification>>);
+  });
+
+  it("returns 401 without Vercel cron header or bearer secret", async () => {
+    const request = createMockRequest("http://localhost:3000/api/cron/expire-posts");
+    const response = await GET(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("allows Vercel cron header without CRON_SECRET", async () => {
+    prisma.post.findMany = vi.fn().mockResolvedValue([]);
+    prisma.post.updateMany = vi.fn().mockResolvedValue({ count: 0 });
+
+    const request = createMockRequest("http://localhost:3000/api/cron/expire-posts", {
+      headers: { "x-vercel-cron": "1" },
+    });
+    const response = await GET(request);
+    const { status, data } = await parseResponse(response);
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.expired).toBe(0);
+  });
+
+  it("expires open posts and notifies creators with bearer token", async () => {
+    process.env.CRON_SECRET = "unit-test-secret";
+
+    prisma.post.findMany = vi
+      .fn()
+      .mockResolvedValue([
+        { id: "post_a", userId: "user_a", title: "Giveaway A" },
+      ]);
+    prisma.post.updateMany = vi.fn().mockResolvedValue({ count: 1 });
+
+    const request = createMockRequest("http://localhost:3000/api/cron/expire-posts", {
+      headers: { authorization: "Bearer unit-test-secret" },
+    });
+    const response = await GET(request);
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.expired).toBe(1);
+    expect(prisma.post.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: "open",
+          endsAt: { lt: expect.any(Date) },
+        }),
+        data: { status: "expired" },
+      }),
+    );
+    expect(notifications.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_a",
+        type: "post_closed",
+        link: "/post/post_a",
+      }),
+    );
+  });
+});

--- a/app/tests/api/posts.test.ts
+++ b/app/tests/api/posts.test.ts
@@ -130,6 +130,26 @@ describe("Posts API", () => {
         }),
       );
     });
+
+    it("applies deadline active filter when filter=active", async () => {
+      prisma.post.findMany = vi.fn().mockResolvedValue([]);
+      prisma.post.count = vi.fn().mockResolvedValue(0);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/posts?filter=active&page=1&limit=10",
+      );
+      const response = await GET(request);
+      const { status } = await parseResponse(response);
+
+      expect(status).toBe(200);
+      expect(prisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            endsAt: { gt: expect.any(Date) },
+          }),
+        }),
+      );
+    });
   });
 
   describe("POST /api/posts", () => {

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/expire-posts",
+      "schedule": "0 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #194 

Summary

This PR introduces automatic expiration for giveaway posts based on their endsAt field, along with UI improvements to reflect remaining time and active status.

Problem

Giveaway posts include an endsAt DateTime field, but there was no mechanism to enforce expiration. As a result, posts remained open indefinitely, even after their deadline passed.

What Was Done
🔄 Backend (Automation)
Implemented a scheduled job (cron) that runs every hour
The job:

Finds all posts where:

status = 'open' AND endsAt < NOW()

Updates their status to:

status = 'expired'
Ensures giveaways automatically transition to the correct state without manual intervention

Verification
 Cron job runs successfully and updates expired posts
 Posts with past endsAt are marked as expired
 Countdown timer displays correctly on PostCard and detail page
 Timeline "Active" tab only shows posts with endsAt > NOW()
 No regression in post rendering or interactions