### PR TITLE
fixed both post api

### DIFF
--- a/app/app/api/posts/route.ts
+++ b/app/app/api/posts/route.ts
@@ -199,13 +199,17 @@ const GET = async (request: NextRequest) => {
     const { searchParams } = new URL(request.url);
 
     const q = searchParams.get("q");
-    const category = searchParams.get("category");
+    const type = searchParams.get("type");
     const sort = searchParams.get("sort");
     const filter = searchParams.get("filter");
+    const userId = searchParams.get("userId");
+    const status = searchParams.get("status");
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
     const page = parseInt(searchParams.get("page") || "1");
     const limit = parseInt(searchParams.get("limit") || "10");
 
-    const where: any = {};
+    const where: Prisma.PostWhereInput = {};
 
     if (filter === "active") {
       where.endsAt = { gt: new Date() };
@@ -218,13 +222,29 @@ const GET = async (request: NextRequest) => {
       ];
     }
 
-    if (category) {
-      where.category = category;
+    if (type) {
+      where.type = type as Prisma.PostTypeFilter;
     }
 
-    let orderBy: any = [{ createdAt: "desc" }];
+    if (userId) {
+      where.userId = userId;
+    }
+
+    if (status) {
+      where.status = status as Prisma.PostStatusFilter;
+    }
+
+    if (from || to) {
+      where.createdAt = {};
+      if (from) where.createdAt.gte = new Date(from);
+      if (to) where.createdAt.lte = new Date(to);
+    }
+
+    let orderBy: Prisma.PostOrderByWithRelationInput[] = [{ createdAt: "desc" }];
     if (sort === "popular") {
-      orderBy = [{ likes: "desc" }, { entries: "desc" }];
+      orderBy = [{ _count: { interactions: "desc" } }, { createdAt: "desc" }];
+    } else if (sort === "ending_soon") {
+      orderBy = [{ endsAt: "asc" }];
     }
 
     const [posts, total] = await Promise.all([
@@ -239,6 +259,13 @@ const GET = async (request: NextRequest) => {
               id: true,
               name: true,
               avatarUrl: true,
+            },
+          },
+          _count: {
+            select: {
+              entries: true,
+              interactions: true,
+              comments: true,
             },
           },
         },

--- a/app/app/api/posts/test.ts
+++ b/app/app/api/posts/test.ts
@@ -21,9 +21,9 @@ const testPostsAPI = async () => {
     console.log('  First title  :', json1.data?.posts?.[0]?.title || '(no posts)');
     console.log('----------------------------------------\n');
 
-    console.log('[2] GET /api/posts  →  giveaway + crypto + small page');
+    console.log('[2] GET /api/posts  →  giveaway + small page');
     const req2 = new Request(
-        `${BASE_URL}?page=1&limit=3&type=giveaway&category=crypto`
+        `${BASE_URL}?page=1&limit=3&type=giveaway`
     );
     const res2 = await GET(req2 as any);
     const json2 = await res2.json();

--- a/app/tests/api/posts.test.ts
+++ b/app/tests/api/posts.test.ts
@@ -102,8 +102,8 @@ describe("Posts API", () => {
       expect(data.data.limit).toBe(10);
     });
 
-    // ✅ NEW TEST: search query, category, sort
-    it("should handle search query, category filter, and sort", async () => {
+    // ✅ NEW TEST: search query, type filter, sort
+    it("should handle search query, type filter, and sort", async () => {
       const mockPosts = [
         { id: "post_1", title: "Awesome Post", user: testUser },
         { id: "post_2", title: "Another Post", user: testUser },
@@ -113,7 +113,7 @@ describe("Posts API", () => {
       prisma.post.count = vi.fn().mockResolvedValue(mockPosts.length);
 
       const request = createMockRequest(
-        "http://localhost:3000/api/posts?q=awesome&category=electronics&sort=popular",
+        "http://localhost:3000/api/posts?q=awesome&type=giveaway&sort=popular",
       );
       const response = await GET(request);
       const { status, data } = await parseResponse(response);
@@ -124,9 +124,54 @@ describe("Posts API", () => {
         expect.objectContaining({
           where: expect.objectContaining({
             OR: expect.any(Array),
-            category: "electronics",
+            type: "giveaway",
           }),
-          orderBy: [{ likes: "desc" }, { entries: "desc" }],
+          orderBy: [{ _count: { interactions: "desc" } }, { createdAt: "desc" }],
+        }),
+      );
+    });
+
+    it("should filter by userId, status, and date range", async () => {
+      const mockPosts = [{ id: "post_1", title: "User Post", user: testUser }];
+
+      prisma.post.findMany = vi.fn().mockResolvedValue(mockPosts);
+      prisma.post.count = vi.fn().mockResolvedValue(mockPosts.length);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/posts?userId=user_123&status=open&from=2024-01-01&to=2024-12-31",
+      );
+      const response = await GET(request);
+      const { status } = await parseResponse(response);
+
+      expect(status).toBe(200);
+      expect(prisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId: "user_123",
+            status: "open",
+            createdAt: expect.objectContaining({
+              gte: expect.any(Date),
+              lte: expect.any(Date),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should sort by ending_soon", async () => {
+      prisma.post.findMany = vi.fn().mockResolvedValue([]);
+      prisma.post.count = vi.fn().mockResolvedValue(0);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/posts?sort=ending_soon",
+      );
+      const response = await GET(request);
+      const { status } = await parseResponse(response);
+
+      expect(status).toBe(200);
+      expect(prisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: [{ endsAt: "asc" }],
         }),
       );
     });


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

---

## Checklist
- [ ] I have tested my changes locally
- [ ] I have updated documentation as needed
- [ ] I have run `npx prisma generate` after schema changes
- [ ] I have run `npx prisma migrate dev` or `npx prisma migrate deploy` as appropriate

---

## Post-Merge Steps for Maintainers

**If this PR includes changes to the Prisma schema:**

1. Run the following command to apply the migration to your database:
   
   ```sh
   npx prisma migrate deploy
   ```
   or, for local development:
   ```sh
   npx prisma migrate dev
   ```
2. Ensure your CI pipeline runs the migration before tests (add this step if missing):
   ```yaml
   - name: Run Prisma Migrate
     run: npx prisma migrate deploy
   ```
3. Make sure the database user in CI has permission to run migrations.

---

If you have any questions, please comment on this PR.
app/app/api/posts/route.ts
Replaced category with type filtering — the query now reads type and maps it to Prisma.PostTypeFilter
Fixed popular sorting — changed from invalid scalar references (likes, entries) to valid Prisma relation-count ordering:

Added userId filter — maps directly to where.userId
Added status filter — maps to Prisma.PostStatusFilter
Added date range filters — from and to query params filter on createdAt (gte / lte)
Added ending_soon sort — sort=ending_soon orders by endsAt: "asc"
Added _count include — response now includes counts for entries, interactions, and comments (consistent with other post endpoints)
app/tests/api/posts.test.ts
Updated existing test to use type=giveaway instead of category=electronics
Updated sort assertion to match the new _count based ordering
Added new tests for userId + status + date range filtering

closes #274 
closes #275 