### PR TITLE
feat(backend): retire mock wallet auth and unify challenge verification

### DIFF
--- a/app/app/api/auth/legacy-login/route.ts
+++ b/app/app/api/auth/legacy-login/route.ts
@@ -1,25 +1,4 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
-import { createToken } from "@/lib/jwt";
-import { z } from "zod";
-
-const loginSchema = z.object({
-  walletAddress: z.string().min(1, "Wallet address is required"),
-  signature: z.string().min(1, "Signature is required"),
-  message: z.string().min(1, "Message is required"),
-});
-
-// Mock wallet signature verification - replace with actual implementation
-async function verifyWalletSignature(
-  walletAddress: string,
-  signature: string,
-  message: string
-): Promise<boolean> {
-  // In production, verify the signature using the wallet's public key
-  // This is a mock implementation for demonstration
-  console.log(`Verifying signature for wallet: ${walletAddress}`);
-  return signature.length > 10; // Simple validation for demo
-}
 
 /**
  * Handles user login with wallet signature.
@@ -32,77 +11,15 @@ async function verifyWalletSignature(
  */
 export async function POST(request: Request) {
   try {
-    const body = await request.json();
-    const parsed = loginSchema.safeParse(body);
-
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: "Invalid request data", details: parsed.error.issues },
-        { status: 400 }
-      );
-    }
-
-    const { walletAddress, signature, message } = parsed.data;
-
-    // Verify wallet signature
-    const isValidSignature = await verifyWalletSignature(walletAddress, signature, message);
-    
-    if (!isValidSignature) {
-      return NextResponse.json(
-        { error: "Invalid wallet signature" },
-        { status: 401 }
-      );
-    }
-
-    // Find user by wallet address
-    const user = await prisma.user.findUnique({
-      where: { walletAddress },
-    });
-
-    if (!user) {
-      return NextResponse.json(
-        { error: "User not found. Please register first." },
-        { status: 404 }
-      );
-    }
-
-    // Create JWT token
-    const token = await createToken({
-      userId: user.id,
-      walletAddress: user.walletAddress,
-      username: user.name,
-    });
-
-    // Create response with cookie
-    const response = NextResponse.json({
-      success: true,
-      user: {
-        id: user.id,
-        walletAddress: user.walletAddress,
-        username: user.name,
-        email: null,
-        avatar: user.avatarUrl,
-        bio: user.bio,
-        joinDate: user.createdAt,
+    void request;
+    return NextResponse.json(
+      {
+        error: "Legacy wallet authentication retired",
+        message:
+          "Use the challenge and verify flow instead: GET /api/auth/challenge then POST /api/auth/verify.",
       },
-      token, // Also return token in response body for client storage
-    }, {
-      headers: {
-        // RFC 299: Miscellaneous persistent warning
-        "Warning": '299 - "Deprecated: This endpoint is legacy. Use Auth.js signIn instead."',
-      },
-    });
-
-    // Set secure cookie
-    response.cookies.set("auth-token", token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 30 * 24 * 60 * 60, // 30 days
-      path: "/",
-    });
-
-    return response;
+      { status: 410 }
+    );
   } catch (error) {
     console.error("Login error:", error);
     return NextResponse.json(

--- a/app/app/api/auth/legacy-register/route.ts
+++ b/app/app/api/auth/legacy-register/route.ts
@@ -1,26 +1,4 @@
 import { NextResponse } from "next/server";
-import { createToken } from "@/lib/jwt";
-import { prisma } from "@/lib/prisma";
-import { z } from "zod";
-
-const registerSchema = z.object({
-  walletAddress: z.string().min(1, "Wallet address is required"),
-  signature: z.string().min(1, "Signature is required"),
-  message: z.string().min(1, "Message is required"),
-  username: z.string().min(3, "Username must be at least 3 characters").max(30, "Username too long"),
-  email: z.string().email("Invalid email").optional(),
-});
-
-// Mock wallet signature verification - replace with actual implementation
-async function verifyWalletSignature (
-  walletAddress: string,
-  signature: string,
-  message: string
-): Promise<boolean> {
-  // In production, verify the signature using the wallet's public key
-  console.log(`Verifying signature for wallet: ${walletAddress}`);
-  return signature.length > 10; // Simple validation for demo
-}
 
 /**
  * Handles user registration with wallet signature.
@@ -33,100 +11,15 @@ async function verifyWalletSignature (
  */
 export async function POST (request: Request) {
   try {
-    const body = await request.json();
-    const parsed = registerSchema.safeParse(body);
-
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: "Invalid request data", details: parsed.error.issues },
-        { status: 400 }
-      );
-    }
-
-    const { walletAddress, signature, message, username, email } = parsed.data;
-
-    // Verify wallet signature
-    const isValidSignature = await verifyWalletSignature(walletAddress, signature, message);
-
-    if (!isValidSignature) {
-      return NextResponse.json(
-        { error: "Invalid wallet signature" },
-        { status: 401 }
-      );
-    }
-
-    // Check if user already exists
-    const existingUser = await prisma.user.findUnique({
-      where: { walletAddress },
-    });
-
-    if (existingUser) {
-      return NextResponse.json(
-        { error: "User with this wallet address already exists" },
-        { status: 409 }
-      );
-    }
-
-    // Check if username is taken
-    const existingUsers = await prisma.user.findMany({
-      where: { name: username },
-    });
-
-    if (existingUsers.length > 0) {
-      return NextResponse.json(
-        { error: "Username already taken" },
-        { status: 409 }
-      );
-    }
-
-    // Create new user
-    const user = await prisma.user.create({
-      data: {
-        walletAddress,
-        name: username,
-        bio: null,
-        avatarUrl: `https://api.dicebear.com/7.x/identicon/svg?seed=${walletAddress}`,
-        xp: 0,
+    void request;
+    return NextResponse.json(
+      {
+        error: "Legacy wallet authentication retired",
+        message:
+          "Use the challenge and verify flow instead: GET /api/auth/challenge then POST /api/auth/verify.",
       },
-    });
-
-    // Create JWT token
-    const token = await createToken({
-      userId: user.id,
-      walletAddress: user.walletAddress,
-      username: user.name,
-    });
-
-    // Create response with cookie
-    const response = NextResponse.json({
-      success: true,
-      user: {
-        id: user.id,
-        walletAddress: user.walletAddress,
-        username: user.name,
-        email: null,
-        avatar: user.avatarUrl,
-        bio: user.bio,
-        joinDate: user.createdAt,
-      },
-      token,
-    }, {
-      headers: {
-        // RFC 299: Miscellaneous persistent warning
-        "Warning": '299 - "Deprecated: This endpoint is legacy. Use Auth.js signIn instead."',
-      },
-    });
-
-    // Set secure cookie
-    response.cookies.set("auth-token", token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 30 * 24 * 60 * 60, // 30 days
-      path: "/",
-    });
-
-    return response;
+      { status: 410 }
+    );
   } catch (error) {
     console.error("Registration error:", error);
     return NextResponse.json(

--- a/app/app/api/auth/verify/route.ts
+++ b/app/app/api/auth/verify/route.ts
@@ -22,15 +22,16 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { verifyChallenge } from "@/lib/sep10";
 import { createToken } from "@/lib/jwt";
-import { prisma } from "@/lib/prisma";
+import { authenticateWalletWithChallenge } from "@/lib/wallet-auth";
 import { z } from "zod";
 
 // Validation schema for the request body
 const verifyRequestSchema = z.object({
   transaction: z.string().min(1, "Transaction XDR is required"),
   publicKey: z.string().length(56, "Invalid Stellar public key"),
+  username: z.string().min(3).max(30).optional(),
+  email: z.string().email().optional(),
 });
 
 /**
@@ -53,64 +54,31 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    const { transaction: signedXDR, publicKey: clientPublicKey } = validationResult.data;
+    const {
+      transaction: signedXDR,
+      publicKey: clientPublicKey,
+      username,
+      email,
+    } = validationResult.data;
 
-    // Step 1: Check if this transaction has already been used (replay attack prevention)
-    const transactionHash = await getTransactionHash(signedXDR);
-    const existingChallenge = await prisma.usedChallenge.findUnique({
-      where: { transactionHash },
+    const authResult = await authenticateWalletWithChallenge({
+      walletAddress: clientPublicKey,
+      transaction: signedXDR,
+      username,
+      email,
     });
 
-    if (existingChallenge) {
+    if (!authResult.success) {
       return NextResponse.json(
         {
-          error: "Replay attack detected",
-          message: "This signature has already been used. Please request a new challenge.",
+          error: authResult.error,
+          message: authResult.message,
         },
-        { status: 403 }
+        { status: authResult.status }
       );
     }
 
-    // Step 2: Verify the signed challenge transaction
-    const verificationResult = verifyChallenge(signedXDR, clientPublicKey);
-
-    if (!verificationResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Verification failed",
-          message: verificationResult.error || "Invalid signature",
-        },
-        { status: 401 }
-      );
-    }
-
-    // Step 3: Mark this transaction as used to prevent replay attacks
-    await prisma.usedChallenge.create({
-      data: {
-        transactionHash,
-        publicKey: clientPublicKey,
-        usedAt: new Date(),
-      },
-    });
-
-    // Step 4: Find or create the user
-    let user = await prisma.user.findUnique({
-      where: { walletAddress: clientPublicKey },
-    });
-
-    // If user doesn't exist, create a new user with default values
-    if (!user) {
-      user = await prisma.user.create({
-        data: {
-          walletAddress: clientPublicKey,
-          name: `User_${clientPublicKey.slice(0, 8)}`,
-          username: `user_${clientPublicKey.slice(0, 8)}`,
-          avatarUrl: `https://api.dicebear.com/7.x/identicon/svg?seed=${clientPublicKey}`,
-          xp: 0,
-          walletBalance: 0,
-        },
-      });
-    }
+    const { user } = authResult;
 
     // Step 5: Generate JWT token
     const token = await createToken({
@@ -174,18 +142,3 @@ export async function OPTIONS(): Promise<NextResponse> {
   });
 }
 
-/**
- * Helper function to extract transaction hash from XDR
- * This is a simplified version - in production, use proper XDR parsing
- */
-async function getTransactionHash(signedXDR: string): Promise<string> {
-  // Import dynamically to avoid issues if stellar-sdk isn't available at build time
-  const { TransactionBuilder, Networks } = await import("@stellar/stellar-sdk");
-  
-  const transaction = TransactionBuilder.fromXDR(
-    signedXDR,
-    Networks.PUBLIC
-  );
-  
-  return transaction.hash().toString("hex");
-}

--- a/app/components/wallet-login-form.tsx
+++ b/app/components/wallet-login-form.tsx
@@ -17,7 +17,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import {
   isConnected,
-  signMessage as freighterSignMessage,
+  signTransaction as freighterSignTransaction,
 } from "@stellar/freighter-api";
 
 /**
@@ -42,89 +42,93 @@ export function WalletLoginForm({
   const [walletAddress, setWalletAddress] = useState("");
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
-  const [signature, setSignature] = useState("");
-  const [message, setMessage] = useState("");
+  const [challengeXdr, setChallengeXdr] = useState("");
+  const [signedTransaction, setSignedTransaction] = useState("");
 
-  // Generate actual signature using Freighter
-  const handleSignMessage = async () => {
+  const fetchChallenge = async () => {
+    if (!walletAddress) {
+      showToast("Please enter your wallet address first", "error");
+      return null;
+    }
+
+    try {
+      const response = await fetch(
+        `/api/auth/challenge?publicKey=${encodeURIComponent(walletAddress)}`,
+        { cache: "no-store" },
+      );
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data?.message || "Failed to fetch challenge");
+      }
+
+      setChallengeXdr(data.transaction);
+      return data as { transaction: string; network_passphrase: string };
+    } catch (error) {
+      console.error("Challenge error:", error);
+      showToast("Could not generate a secure challenge. Please try again.", "error");
+      return null;
+    }
+  };
+
+  const handleSignChallenge = async () => {
     if (!walletAddress) {
       showToast("Please enter your wallet address first", "error");
       return;
     }
 
     try {
-      // Check if Freighter is available
       const connected = await isConnected();
       if (!connected) {
-        showToast(
-          "Freighter wallet is not installed or not connected",
-          "error",
-        );
+        showToast("Freighter wallet is not installed or not connected", "error");
         return;
       }
 
-      const msg = message || (await generateSignMessage());
+      const challenge = challengeXdr
+        ? {
+            transaction: challengeXdr,
+            network_passphrase: "Public Global Stellar Network ; September 2015",
+          }
+        : await fetchChallenge();
 
-      if (!msg) {
-        showToast("Failed to generate sign message", "error");
+      if (!challenge) {
         return;
       }
 
-      let signedMsg;
-      try {
-        signedMsg = await freighterSignMessage(msg, {
-          networkPassphrase: "Test SDF Network ; September 2015", // fallback or configurable
-        });
-      } catch (err) {
-        // Fallback for cases where it doesn't take options or simple reject
-        signedMsg = await freighterSignMessage(msg);
+      const signedResult = await (freighterSignTransaction as any)(
+        challenge.transaction,
+        {
+          networkPassphrase: challenge.network_passphrase,
+        },
+      );
+
+      const signedXdr =
+        typeof signedResult === "string"
+          ? signedResult
+          : signedResult?.signedTxXdr ||
+            signedResult?.signedTransaction ||
+            signedResult?.txXdr ||
+            null;
+
+      if (!signedXdr) {
+        throw new Error("Freighter did not return a signed transaction");
       }
 
-      if (signedMsg) {
-        if (typeof signedMsg === "string") {
-          setSignature(signedMsg);
-        } else if (
-          typeof signedMsg === "object" &&
-          typeof (signedMsg as any).signature === "string"
-        ) {
-          setSignature((signedMsg as any).signature);
-        } else {
-          setSignature(signedMsg.toString());
-        }
-        showToast("Message signed successfully", "success");
-      }
+      setSignedTransaction(signedXdr);
+      showToast("Challenge signed successfully", "success");
     } catch (error) {
       console.error("Signing error:", error);
-      showToast("Error signing the message", "error");
+      showToast("Error signing the challenge", "error");
     }
   };
 
-  // Fetch a server-issued nonce
-  const generateSignMessage = async () => {
-    if (!walletAddress) {
-      showToast("Please enter your wallet address first", "error");
+  const authenticate = async (mode: "login" | "register") => {
+    if (!walletAddress || !signedTransaction) {
+      showToast("Please sign the wallet challenge first", "error");
       return;
     }
 
-    try {
-      const response = await fetch("/api/auth/nonce");
-      if (!response.ok) throw new Error("Failed to fetch nonce");
-
-      const { nonce } = await response.json();
-      const msg = `Sign this message to authenticate with Geev\n\nWallet: ${walletAddress}\nNonce: ${nonce}`;
-      setMessage(msg);
-      return msg;
-    } catch (error) {
-      console.error("Error generating nonce:", error);
-      showToast(
-        "Could not generate a secure nonce. Please try again.",
-        "error",
-      );
-    }
-  };
-
-  const handleLogin = async () => {
-    if (!walletAddress || !signature || !message) {
+    if (mode === "register" && !username) {
       showToast("Please fill in all required fields", "error");
       return;
     }
@@ -134,53 +138,36 @@ export function WalletLoginForm({
     try {
       const result = await signIn("credentials", {
         walletAddress,
-        signature,
-        message,
+        transaction: signedTransaction,
+        username: mode === "register" ? username : undefined,
+        email: mode === "register" ? email || undefined : undefined,
         redirect: false,
       });
 
       if (result?.ok && !result.error) {
-        showToast("Successfully logged in!", "success");
+        showToast(
+          mode === "login"
+            ? "Successfully logged in!"
+            : "Account created successfully!",
+          "success",
+        );
         router.push("/feed");
         return;
       }
 
-      showToast(result?.error || "Login failed", "error");
+      showToast(
+        result?.error ||
+          (mode === "login" ? "Login failed" : "Registration failed"),
+        "error",
+      );
     } catch (error) {
-      console.error("Login error:", error);
-      showToast("Login failed. Please try again.", "error");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleRegister = async () => {
-    if (!walletAddress || !username || !signature || !message) {
-      showToast("Please fill in all required fields", "error");
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      const result = await signIn("credentials", {
-        walletAddress,
-        signature,
-        message,
-        username,
-        email: email || undefined,
-        redirect: false,
-      });
-
-      if (result?.ok && !result.error) {
-        showToast("Account created successfully!", "success");
-        router.push("/feed");
-      } else {
-        showToast(result?.error || "Registration failed", "error");
-      }
-    } catch (error) {
-      console.error("Registration error:", error);
-      showToast("Registration failed. Please try again.", "error");
+      console.error("Authentication error:", error);
+      showToast(
+        mode === "login"
+          ? "Login failed. Please try again."
+          : "Registration failed. Please try again.",
+        "error",
+      );
     } finally {
       setIsLoading(false);
     }
@@ -240,18 +227,18 @@ export function WalletLoginForm({
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium">Signature</label>
+            <label className="text-sm font-medium">Signed Challenge</label>
             <div className="flex gap-2">
               <Input
-                placeholder="Signature from wallet"
-                value={signature}
-                onChange={(e) => setSignature(e.target.value)}
+                placeholder="Signed transaction from Freighter"
+                value={signedTransaction}
+                onChange={(e) => setSignedTransaction(e.target.value)}
                 className="flex-1"
               />
               <Button
                 type="button"
                 variant="outline"
-                onClick={handleSignMessage}
+                onClick={handleSignChallenge}
               >
                 <Key className="h-4 w-4" />
               </Button>
@@ -259,28 +246,28 @@ export function WalletLoginForm({
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium">Message to Sign</label>
+            <label className="text-sm font-medium">Challenge Transaction</label>
             <div className="relative">
               <textarea
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
+                value={challengeXdr}
+                onChange={(e) => setChallengeXdr(e.target.value)}
                 className="flex min-h-20 w-full rounded-md border border-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-0"
-                placeholder="Message to sign..."
+                placeholder="Server-issued challenge transaction..."
               />
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 className="absolute top-2 right-2"
-                onClick={() => generateSignMessage()}
+                onClick={() => fetchChallenge()}
               >
-                Generate
+                Fetch
               </Button>
             </div>
           </div>
 
           <Button
-            onClick={handleLogin}
+            onClick={() => authenticate("login")}
             disabled={isLoading}
             className="w-full bg-linear-to-r from-orange-500 to-red-600 hover:from-orange-600 hover:to-red-700 text-white"
           >
@@ -333,18 +320,18 @@ export function WalletLoginForm({
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium">Signature</label>
+            <label className="text-sm font-medium">Signed Challenge</label>
             <div className="flex gap-2">
               <Input
-                placeholder="Signature from wallet"
-                value={signature}
-                onChange={(e) => setSignature(e.target.value)}
+                placeholder="Signed transaction from Freighter"
+                value={signedTransaction}
+                onChange={(e) => setSignedTransaction(e.target.value)}
                 className="flex-1"
               />
               <Button
                 type="button"
                 variant="outline"
-                onClick={handleSignMessage}
+                onClick={handleSignChallenge}
               >
                 <Key className="h-4 w-4" />
               </Button>
@@ -352,28 +339,28 @@ export function WalletLoginForm({
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium">Message to Sign</label>
+            <label className="text-sm font-medium">Challenge Transaction</label>
             <div className="relative">
               <textarea
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
+                value={challengeXdr}
+                onChange={(e) => setChallengeXdr(e.target.value)}
                 className="flex min-h-20 w-full rounded-md border border-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                placeholder="Message to sign..."
+                placeholder="Server-issued challenge transaction..."
               />
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 className="absolute top-2 right-2"
-                onClick={() => generateSignMessage()}
+                onClick={() => fetchChallenge()}
               >
-                Generate
+                Fetch
               </Button>
             </div>
           </div>
 
           <Button
-            onClick={handleRegister}
+            onClick={() => authenticate("register")}
             disabled={isLoading}
             className="w-full bg-linear-to-r from-orange-500 to-red-600 hover:from-orange-600 hover:to-red-700 text-white"
           >
@@ -385,9 +372,8 @@ export function WalletLoginForm({
 
       <div className="mt-6 p-4 bg-orange-50 dark:bg-orange-950/30 rounded-lg">
         <p className="text-sm text-orange-700 dark:text-orange-300">
-          <strong>Note:</strong> This is a demo implementation. In production,
-          you would integrate with actual wallet providers like MetaMask or
-          WalletConnect.
+          <strong>Note:</strong> Wallet auth now uses a signed Stellar
+          challenge transaction before a session is issued.
         </p>
       </div>
     </div>

--- a/app/lib/auth-config.ts
+++ b/app/lib/auth-config.ts
@@ -4,17 +4,7 @@ import { JWT } from "next-auth/jwt";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { PrismaAdapter } from "@auth/prisma-adapter"
-import { Keypair } from "@stellar/stellar-sdk";
-
-// Lazy import SEP-10 functions to avoid initialization errors during tests
-let _verifyChallenge: typeof import("@/lib/sep10").verifyChallenge | null = null;
-async function getVerifyChallenge() {
-  if (!_verifyChallenge) {
-    const sep10 = await import("@/lib/sep10");
-    _verifyChallenge = sep10.verifyChallenge;
-  }
-  return _verifyChallenge;
-}
+import { authenticateWalletWithChallenge } from "@/lib/wallet-auth";
 
 // JWT payload structure
 interface UserJWT extends JWT {
@@ -34,100 +24,6 @@ interface UserSession {
   joinDate: Date;
 }
 
-/**
- * Legacy wallet signature validation using simple message signing
- * Used for backwards compatibility with existing clients
- */
-async function verifyWalletSignature (
-  walletAddress: string,
-  signature: string,
-  message: string
-): Promise<boolean> {
-  try {
-    // Step 1: Verify cryptography
-    const keypair = Keypair.fromPublicKey(walletAddress);
-    // Freighter returns base64 string for signMessage, so we parse it into Buffer to verify
-    const isValidSignature = keypair.verify(Buffer.from(message), Buffer.from(signature, "base64"));
-    
-    if (!isValidSignature) return false;
-
-    // Step 2: Verify and consume nonce to prevent replay attacks
-    const nonceMatch = message.match(/Nonce: ([a-f0-9]+)/);
-    if (!nonceMatch) {
-      console.error("No nonce found in message");
-      return false;
-    }
-
-    const nonce = nonceMatch[1];
-    const authNonce = await prisma.authNonce.findUnique({
-      where: { nonce },
-    });
-
-    if (!authNonce || authNonce.used || authNonce.expiresAt < new Date()) {
-      console.error("Invalid, used, or expired nonce");
-      return false;
-    }
-
-    // Consume the nonce
-    await prisma.authNonce.update({
-      where: { nonce },
-      data: { used: true },
-    });
-
-    return true;
-  } catch (error) {
-    console.error("Invalid signature or verification failed:", error);
-    return false;
-  }
-}
-
-
-/**
- * SEP-10 transaction verification with replay attack prevention
- * This is the recommended authentication method for Stellar wallets
- */
-async function verifySEP10Transaction(
-  signedXDR: string,
-  walletAddress: string
-): Promise<{ valid: boolean; error?: string }> {
-  try {
-    // Step 1: Check if this transaction has already been used (replay attack prevention)
-    const { TransactionBuilder, Networks } = await import("@stellar/stellar-sdk");
-    const transaction = TransactionBuilder.fromXDR(signedXDR, Networks.PUBLIC);
-    const transactionHash = transaction.hash().toString("hex");
-
-    const existingChallenge = await prisma.usedChallenge.findUnique({
-      where: { transactionHash },
-    });
-
-    if (existingChallenge) {
-      return { valid: false, error: "Replay attack detected: This signature has already been used" };
-    }
-
-    // Step 2: Verify the signed challenge transaction
-    const verifyChallenge = await getVerifyChallenge();
-    const verificationResult = verifyChallenge(signedXDR, walletAddress);
-
-    if (!verificationResult.valid) {
-      return { valid: false, error: verificationResult.error };
-    }
-
-    // Step 3: Mark this transaction as used to prevent replay attacks
-    await prisma.usedChallenge.create({
-      data: {
-        transactionHash,
-        publicKey: walletAddress,
-        usedAt: new Date(),
-      },
-    });
-
-    return { valid: true };
-  } catch (error) {
-    console.error("SEP-10 verification error:", error);
-    return { valid: false, error: "Failed to verify SEP-10 transaction" };
-  }
-}
-
 export const authConfig = {
   adapter: PrismaAdapter(prisma),
   providers: [
@@ -135,22 +31,15 @@ export const authConfig = {
       name: "Wallet",
       credentials: {
         walletAddress: { label: "Wallet Address", type: "text" },
-        signature: { label: "Signature", type: "text" },
-        message: { label: "Message", type: "text" },
         transaction: { label: "SEP-10 Transaction XDR", type: "text" },
         username: { label: "Username", type: "text", optional: true },
         email: { label: "Email", type: "email", optional: true },
       },
       async authorize (credentials: any) {
-        // Parse credentials with support for both legacy and SEP-10 authentication
         const parsedCredentials = z
           .object({
             walletAddress: z.string().regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address (must start with G and be 56 characters long)"),
-            // Legacy authentication fields
-            signature: z.string().optional().nullable(),
-            message: z.string().optional().nullable(),
-            // SEP-10 authentication field
-            transaction: z.string().optional().nullable(),
+            transaction: z.string().min(1, "SEP-10 transaction is required"),
             username: z.string().optional().nullable(),
             email: z.string().email().optional().nullable(),
           })
@@ -160,73 +49,26 @@ export const authConfig = {
           return null;
         }
 
-        const { walletAddress, signature, message, transaction, username, email } = parsedCredentials.data;
+        const { walletAddress, transaction, username, email } = parsedCredentials.data;
 
         try {
-          let isAuthenticated = false;
-
-          // Determine authentication method and verify
-          if (transaction) {
-            // SEP-10 Transaction-based authentication (recommended)
-            const sep10Result = await verifySEP10Transaction(transaction, walletAddress);
-            if (!sep10Result.valid) {
-              console.error("SEP-10 verification failed:", sep10Result.error);
-              throw new Error(sep10Result.error || "Invalid SEP-10 transaction");
-            }
-            isAuthenticated = true;
-          } else if (signature && message) {
-            // Legacy message-based authentication
-            isAuthenticated = await verifyWalletSignature(walletAddress, signature, message);
-            if (!isAuthenticated) {
-              throw new Error("Invalid wallet signature");
-            }
-          } else {
-            throw new Error("Missing authentication credentials. Provide either transaction (SEP-10) or signature+message (legacy).");
-          }
-
-          if (!isAuthenticated) {
-            throw new Error("Authentication failed");
-          }
-
-          // Check if user exists
-          let user = await prisma.user.findUnique({
-            where: { walletAddress },
+          const authResult = await authenticateWalletWithChallenge({
+            walletAddress,
+            transaction,
+            username,
+            email,
           });
 
-          // If user doesn't exist and this is a login attempt, fail
-          if (!user && !username) {
-            throw new Error("User not found. Please register first.");
+          if (!authResult.success) {
+            throw new Error(authResult.message);
           }
-
-          // If user doesn't exist and this is a registration attempt, create user
-          if (!user && username) {
-            // Check if username is already taken
-            const existingUsername = await prisma.user.findUnique({
-              where: { username },
-            });
-
-            if (existingUsername) {
-              throw new Error("Username already taken");
-            }
-
-            user = await prisma.user.create({
-              data: {
-                walletAddress,
-                name: username,
-                username,
-                email: email || null,
-                bio: null,
-                avatarUrl: `https://api.dicebear.com/7.x/identicon/svg?seed=${walletAddress}`,
-                xp: 0,
-              },
-            });
-          }
+          const { user } = authResult;
 
           if (user) {
             return {
               id: user.id,
               walletAddress: user.walletAddress,
-              username: user.name,
+              username: user.username || user.name,
               email: user.email,
               avatar: user.avatarUrl,
               bio: user.bio,

--- a/app/lib/wallet-auth.ts
+++ b/app/lib/wallet-auth.ts
@@ -1,0 +1,124 @@
+import { prisma } from "@/lib/prisma";
+import { verifyChallenge } from "@/lib/sep10";
+
+export type WalletAuthOptions = {
+  walletAddress: string;
+  transaction: string;
+  username?: string | null;
+  email?: string | null;
+};
+
+export type WalletAuthResult =
+  | {
+      success: true;
+      user: {
+        id: string;
+        walletAddress: string;
+        username: string | null;
+        name: string;
+        email: string | null;
+        avatarUrl: string | null;
+        bio: string | null;
+        xp: number;
+        walletBalance: number;
+        createdAt: Date;
+      };
+    }
+  | {
+      success: false;
+      status: number;
+      error: string;
+      message: string;
+    };
+
+export async function authenticateWalletWithChallenge(
+  options: WalletAuthOptions,
+): Promise<WalletAuthResult> {
+  const { walletAddress, transaction, username, email } = options;
+  const transactionHash = await getTransactionHash(transaction);
+
+  const existingChallenge = await prisma.usedChallenge.findUnique({
+    where: { transactionHash },
+  });
+
+  if (existingChallenge) {
+    return {
+      success: false,
+      status: 403,
+      error: "Replay attack detected",
+      message: "This signature has already been used. Please request a new challenge.",
+    };
+  }
+
+  const verificationResult = verifyChallenge(transaction, walletAddress);
+
+  if (!verificationResult.valid) {
+    return {
+      success: false,
+      status: 401,
+      error: "Verification failed",
+      message: verificationResult.error || "Invalid signature",
+    };
+  }
+
+  await prisma.usedChallenge.create({
+    data: {
+      transactionHash,
+      publicKey: walletAddress,
+      usedAt: new Date(),
+    },
+  });
+
+  let user = await prisma.user.findUnique({
+    where: { walletAddress },
+  });
+
+  if (!user && username) {
+    const existingUsername = await prisma.user.findUnique({
+      where: { username },
+    });
+
+    if (existingUsername) {
+      return {
+        success: false,
+        status: 409,
+        error: "Username already taken",
+        message: "Choose a different username and try again.",
+      };
+    }
+
+    user = await prisma.user.create({
+      data: {
+        walletAddress,
+        name: username,
+        username,
+        email: email || null,
+        avatarUrl: `https://api.dicebear.com/7.x/identicon/svg?seed=${walletAddress}`,
+        xp: 0,
+        walletBalance: 0,
+      },
+    });
+  }
+
+  if (!user) {
+    user = await prisma.user.create({
+      data: {
+        walletAddress,
+        name: `User_${walletAddress.slice(0, 8)}`,
+        username: `user_${walletAddress.slice(0, 8)}`,
+        email: email || null,
+        avatarUrl: `https://api.dicebear.com/7.x/identicon/svg?seed=${walletAddress}`,
+        xp: 0,
+        walletBalance: 0,
+      },
+    });
+  }
+
+  return { success: true, user };
+}
+
+export async function getTransactionHash(signedXDR: string): Promise<string> {
+  const { TransactionBuilder, Networks } = await import("@stellar/stellar-sdk");
+  const transaction = TransactionBuilder.fromXDR(signedXDR, Networks.PUBLIC);
+  return transaction.hash().toString("hex");
+}

--- a/app/tests/api/auth-credentials.test.ts
+++ b/app/tests/api/auth-credentials.test.ts
@@ -1,222 +1,119 @@
-/**
- * Unit tests for the NextAuth Credentials provider `authorize` function.
- *
- * The application has no separate /api/auth/login or /api/auth/register routes.
- * Both login and registration flow through the Credentials provider's `authorize`
- * callback in lib/auth-config.ts:
- *   - Registration: walletAddress + valid signature + username → creates new user
- *   - Login:        walletAddress + valid signature (no username) → returns existing user
- *
- * We follow the same prisma-stubbing pattern as entries.test.ts / posts.test.ts:
- * import the real prisma singleton and replace individual methods with vi.fn()
- * so that `auth-config.ts` (which captured the same singleton at import time)
- * calls our stubs instead of hitting a real database.
- */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { authConfig } from '@/lib/auth-config';
-// Import the real prisma singleton — we will stub individual methods per test,
-// exactly as entries.test.ts and posts.test.ts do.
-import { prisma } from '@/lib/prisma';
+import { authConfig } from "@/lib/auth-config";
 
-const mockVerify = vi.hoisted(() => vi.fn());
-const mockFromPublicKey = vi.hoisted(() => vi.fn());
+const mockAuthenticateWalletWithChallenge = vi.hoisted(() => vi.fn());
 
-vi.mock('@stellar/stellar-sdk', () => ({
-  Keypair: {
-    fromPublicKey: mockFromPublicKey,
-  },
+vi.mock("@/lib/wallet-auth", () => ({
+  authenticateWalletWithChallenge: mockAuthenticateWalletWithChallenge,
 }));
 
-// PrismaAdapter is invoked at module-evaluation time inside authConfig.
-// Return a no-op object so importing auth-config doesn't attempt a real DB connection.
-vi.mock('@auth/prisma-adapter', () => ({
+vi.mock("@auth/prisma-adapter", () => ({
   PrismaAdapter: vi.fn().mockReturnValue({}),
 }));
 
+const VALID_WALLET_ADDRESS =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
-const VALID_WALLET_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
-const SECOND_VALID_WALLET_ADDRESS = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
-const NONCE = 'abcdef1234567890';
-const SIGN_MESSAGE = `Please sign this message to authenticate with Geev.\nNonce: ${NONCE}`;
-
-describe('Auth Credentials Provider (authorize)', () => {
-  // The Credentials provider is the first (and only) provider in authConfig.
+describe("Auth Credentials Provider (authorize)", () => {
   let authorize: (credentials: Record<string, unknown>) => Promise<unknown>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFromPublicKey.mockReturnValue({ verify: mockVerify });
-    (prisma as any).authNonce ??= {};
-    (prisma as any).authNonce.findUnique = vi.fn().mockResolvedValue({
-      nonce: NONCE,
-      used: false,
-      expiresAt: new Date(Date.now() + 60_000),
-    });
-    (prisma as any).authNonce.update = vi.fn().mockResolvedValue({
-      nonce: NONCE,
-      used: true,
-      expiresAt: new Date(Date.now() + 60_000),
-    });
     authorize = (authConfig.providers[0] as any).options.authorize;
   });
 
-  // ────────────────────────────────────────────────────────────
-  // Registration path
-  // ────────────────────────────────────────────────────────────
-
-  it('should register a new user when valid signature and username are provided', async () => {
-    const walletAddress = VALID_WALLET_ADDRESS;
-    const createdUser = {
-      id: 'new_user_1',
-      walletAddress,
-      name: 'alice',
-      username: 'alice',
-      email: null,
-      bio: null,
-      avatarUrl: `https://api.dicebear.com/7.x/identicon/svg?seed=${walletAddress}`,
-      xp: 0,
-      createdAt: new Date(),
-    };
-
-    mockVerify.mockReturnValue(true);
-    prisma.user.findUnique = vi.fn().mockResolvedValue(null); // user does not exist yet
-    prisma.user.create = vi.fn().mockResolvedValue(createdUser);
-
-    const result = await authorize({
-      walletAddress,
-      signature: 'dmFsaWRzaWduYXR1cmU=',
-      message: SIGN_MESSAGE,
-      username: 'alice',
+  it("registers a user from a verified challenge transaction", async () => {
+    mockAuthenticateWalletWithChallenge.mockResolvedValue({
+      success: true,
+      user: {
+        id: "new_user_1",
+        walletAddress: VALID_WALLET_ADDRESS,
+        username: "alice",
+        name: "alice",
+        email: "alice@example.com",
+        avatarUrl: null,
+        bio: null,
+        xp: 0,
+        walletBalance: 0,
+        createdAt: new Date(),
+      },
     });
-
-    expect(result).not.toBeNull();
-    expect((result as any).walletAddress).toBe(walletAddress);
-    expect(prisma.user.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          walletAddress,
-          name: 'alice',
-          username: 'alice',
-          xp: 0,
-        }),
-      }),
-    );
-  });
-
-  it('should register with an email when email is provided during registration', async () => {
-    const walletAddress = SECOND_VALID_WALLET_ADDRESS;
-    mockVerify.mockReturnValue(true);
-    prisma.user.findUnique = vi.fn().mockResolvedValue(null);
-    prisma.user.create = vi.fn().mockResolvedValue({
-      id: 'new_user_email',
-      walletAddress,
-      name: 'eve',
-      username: 'eve',
-      email: 'eve@example.com',
-      bio: null,
-      avatarUrl: null,
-      xp: 0,
-      createdAt: new Date(),
-    });
-
-    const result = await authorize({
-      walletAddress,
-      signature: 'dmFsaWRzaWduYXR1cmU=',
-      message: SIGN_MESSAGE,
-      username: 'eve',
-      email: 'eve@example.com',
-    });
-
-    expect(result).not.toBeNull();
-    expect(prisma.user.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ email: 'eve@example.com' }),
-      }),
-    );
-  });
-
-  // ────────────────────────────────────────────────────────────
-  // Login path
-  // ────────────────────────────────────────────────────────────
-
-  it('should return user on successful login with an existing account', async () => {
-    const existingUser = {
-      id: 'user_existing',
-      walletAddress: VALID_WALLET_ADDRESS,
-      name: 'Bob',
-      username: 'bob',
-      email: 'bob@example.com',
-      bio: 'My bio',
-      avatarUrl: null,
-      createdAt: new Date(),
-    };
-
-    mockVerify.mockReturnValue(true);
-    prisma.user.findUnique = vi.fn().mockResolvedValue(existingUser);
-    prisma.user.create = vi.fn(); // should not be called
 
     const result = await authorize({
       walletAddress: VALID_WALLET_ADDRESS,
-      signature: 'dmFsaWRzaWduYXR1cmU=',
-      message: SIGN_MESSAGE,
-      // no username → login, not registration
+      transaction: "signed-xdr",
+      username: "alice",
+      email: "alice@example.com",
     });
 
-    expect(result).not.toBeNull();
-    expect((result as any).id).toBe('user_existing');
-    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      id: "new_user_1",
+      walletAddress: VALID_WALLET_ADDRESS,
+      username: "alice",
+      email: "alice@example.com",
+    });
+    expect(mockAuthenticateWalletWithChallenge).toHaveBeenCalledWith({
+      walletAddress: VALID_WALLET_ADDRESS,
+      transaction: "signed-xdr",
+      username: "alice",
+      email: "alice@example.com",
+    });
   });
 
-  // ────────────────────────────────────────────────────────────
-  // Failure paths
-  // ────────────────────────────────────────────────────────────
-
-  it('should return null when signature is invalid', async () => {
-    mockFromPublicKey.mockReturnValue({ verify: vi.fn().mockReturnValue(false) });
+  it("logs in an existing user from a verified challenge transaction", async () => {
+    mockAuthenticateWalletWithChallenge.mockResolvedValue({
+      success: true,
+      user: {
+        id: "user_existing",
+        walletAddress: VALID_WALLET_ADDRESS,
+        username: "bob",
+        name: "Bob",
+        email: "bob@example.com",
+        avatarUrl: null,
+        bio: "My bio",
+        xp: 10,
+        walletBalance: 0,
+        createdAt: new Date(),
+      },
+    });
 
     const result = await authorize({
       walletAddress: VALID_WALLET_ADDRESS,
-      signature: 'bad-sig',
-      message: SIGN_MESSAGE,
+      transaction: "signed-xdr",
+    });
+
+    expect(result).toMatchObject({
+      id: "user_existing",
+      walletAddress: VALID_WALLET_ADDRESS,
+      username: "bob",
+      email: "bob@example.com",
+    });
+  });
+
+  it("rejects legacy signature credentials", async () => {
+    const result = await authorize({
+      walletAddress: VALID_WALLET_ADDRESS,
+      signature: "legacy-signature",
+      message: "legacy-message",
     });
 
     expect(result).toBeNull();
+    expect(mockAuthenticateWalletWithChallenge).not.toHaveBeenCalled();
   });
 
-  it('should return null on login when user does not exist and no username provided', async () => {
-    mockVerify.mockReturnValue(true);
-    prisma.user.findUnique = vi.fn().mockResolvedValue(null); // no such user
-
-    const result = await authorize({
-      walletAddress: SECOND_VALID_WALLET_ADDRESS,
-      signature: 'dmFsaWRzaWduYXR1cmU=',
-      message: SIGN_MESSAGE,
-      // no username → attempted login, not registration
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it('should return null when credentials object is missing required fields', async () => {
-    const result = await authorize({
-      walletAddress: '',
-      signature: '',
-      message: '',
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it('should return null when Keypair.fromPublicKey throws (malformed wallet address)', async () => {
-    mockFromPublicKey.mockImplementation(() => {
-      throw new Error('Invalid Stellar public key');
+  it("returns null when secure verification fails", async () => {
+    mockAuthenticateWalletWithChallenge.mockResolvedValue({
+      success: false,
+      status: 403,
+      error: "Replay attack detected",
+      message:
+        "This signature has already been used. Please request a new challenge.",
     });
 
     const result = await authorize({
-      walletAddress: 'NOT_A_STELLAR_KEY',
-      signature: 'some-sig',
-      message: 'sign-this',
+      walletAddress: VALID_WALLET_ADDRESS,
+      transaction: "replayed-xdr",
     });
 
     expect(result).toBeNull();

--- a/app/tests/lib/wallet-auth.test.ts
+++ b/app/tests/lib/wallet-auth.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFindUsedChallenge = vi.hoisted(() => vi.fn());
+const mockCreateUsedChallenge = vi.hoisted(() => vi.fn());
+const mockFindUser = vi.hoisted(() => vi.fn());
+const mockCreateUser = vi.hoisted(() => vi.fn());
+const mockVerifyChallenge = vi.hoisted(() => vi.fn());
+const mockFromXDR = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    usedChallenge: {
+      findUnique: mockFindUsedChallenge,
+      create: mockCreateUsedChallenge,
+    },
+    user: {
+      findUnique: mockFindUser,
+      create: mockCreateUser,
+    },
+  },
+}));
+
+vi.mock("@/lib/sep10", () => ({
+  verifyChallenge: mockVerifyChallenge,
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Networks: {
+    PUBLIC: "Public Global Stellar Network ; September 2015",
+  },
+  TransactionBuilder: {
+    fromXDR: mockFromXDR,
+  },
+}));
+
+describe("authenticateWalletWithChallenge", () => {
+  const walletAddress =
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFromXDR.mockReturnValue({
+      hash: () => Buffer.from("challenge-hash"),
+    });
+  });
+
+  it("blocks replayed challenge transactions", async () => {
+    mockFindUsedChallenge.mockResolvedValue({ id: "used_1" });
+
+    const { authenticateWalletWithChallenge } = await import("@/lib/wallet-auth");
+    const result = await authenticateWalletWithChallenge({
+      walletAddress,
+      transaction: "signed-xdr",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      status: 403,
+      error: "Replay attack detected",
+      message:
+        "This signature has already been used. Please request a new challenge.",
+    });
+    expect(mockVerifyChallenge).not.toHaveBeenCalled();
+  });
+
+  it("creates a new user only after a valid challenge verification", async () => {
+    mockFindUsedChallenge.mockResolvedValue(null);
+    mockVerifyChallenge.mockReturnValue({ valid: true });
+    mockFindUser
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    mockCreateUser.mockResolvedValue({
+      id: "user_1",
+      walletAddress,
+      username: "alice",
+      name: "alice",
+      email: "alice@example.com",
+      avatarUrl: null,
+      bio: null,
+      xp: 0,
+      walletBalance: 0,
+      createdAt: new Date(),
+    });
+
+    const { authenticateWalletWithChallenge } = await import("@/lib/wallet-auth");
+    const result = await authenticateWalletWithChallenge({
+      walletAddress,
+      transaction: "signed-xdr",
+      username: "alice",
+      email: "alice@example.com",
+    });
+
+    expect(mockCreateUsedChallenge).toHaveBeenCalledTimes(1);
+    expect(mockCreateUser).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        walletAddress,
+        username: "alice",
+        name: "alice",
+        email: "alice@example.com",
+      }),
+    });
+    expect(result).toMatchObject({
+      success: true,
+      user: {
+        id: "user_1",
+        walletAddress,
+        username: "alice",
+      },
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## Description

Retires the legacy mock wallet authentication path and makes the SEP-10 challenge/verify flow the canonical production auth model for both login and registration.

Fixes #306

This change removes legacy mock signature verification from production auth flows, centralizes secure wallet verification in a shared backend helper, preserves replay protection through used challenge tracking, and updates the wallet auth UI to sign server-issued Stellar challenges instead of plain messages.

---

## Checklist
- [x] I have tested my changes locally
- [x] I have run `npx prisma generate` after schema changes
- [X] I have run `npx prisma migrate dev` or `npx prisma migrate deploy` as appropriate

Notes:
- No Prisma schema changes were made in this PR, so no migration was required.
- Local verification run:
  - `corepack pnpm exec vitest run tests/api/auth-credentials.test.ts tests/lib/wallet-auth.test.ts`
- Prisma client generation run:
  - `npx prisma generate`

---

## Post-Merge Steps for Maintainers

**If this PR includes changes to the Prisma schema:**

1. Run the following command to apply the migration to your database:
   
   ```sh
   npx prisma migrate deploy