### PR TITLE
Fix Auth.js JWT credentials configuration

### DIFF
--- a/app/app/(auth)/me/route.ts
+++ b/app/app/(auth)/me/route.ts
@@ -40,7 +40,6 @@ export async function GET () {
                         followers: true,
                         helpContributions: true,
                         accounts: true,
-                        sessions: true,
                     },
                 },
             },

--- a/app/app/api/auth/me/route.ts
+++ b/app/app/api/auth/me/route.ts
@@ -32,7 +32,6 @@ export async function GET () {
                         followers: true,
                         helpContributions: true,
                         accounts: true,
-                        sessions: true,
                     },
                 },
             },

--- a/app/app/api/dev-users/route.ts
+++ b/app/app/api/dev-users/route.ts
@@ -22,7 +22,6 @@ export async function GET () {
                     followers: true,
                     helpContributions: true,
                     accounts: true,
-                    sessions: true,
                 },
             },
         },

--- a/app/app/api/mock-users/route.ts
+++ b/app/app/api/mock-users/route.ts
@@ -18,8 +18,7 @@ const GET = async () => {
                         followings: true,
                         followers: true,
                         helpContributions: true,
-                        accounts: true,
-                        sessions: true
+                        accounts: true
                     }
                 }
             },

--- a/app/lib/auth-config.ts
+++ b/app/lib/auth-config.ts
@@ -1,31 +1,9 @@
 import { NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
-import { JWT } from "next-auth/jwt";
 import { z } from "zod";
-import { prisma } from "@/lib/prisma";
-import { PrismaAdapter } from "@auth/prisma-adapter"
 import { authenticateWalletWithChallenge } from "@/lib/wallet-auth";
 
-// JWT payload structure
-interface UserJWT extends JWT {
-  id: string;
-  walletAddress: string;
-  username: string;
-}
-
-// User session structure
-interface UserSession {
-  id: string;
-  walletAddress: string;
-  username: string;
-  email: string | null;
-  avatar: string | null;
-  bio: string | null;
-  joinDate: Date;
-}
-
 export const authConfig = {
-  adapter: PrismaAdapter(prisma),
   providers: [
     Credentials({
       name: "Wallet",
@@ -85,7 +63,7 @@ export const authConfig = {
     }),
   ],
   callbacks: {
-    async jwt ({ token, user }): Promise<JWT> {
+    async jwt ({ token, user }) {
       if (user) {
         token.id = user.id;
         // Store walletAddress and username in token

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -23,7 +23,6 @@ export type User = BaseUser & {
     followers: number
     helpContributions: number
     accounts: number
-    sessions: number
   }
 }
 

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,6 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@auth/prisma-adapter": "^2.11.1",
     "browser-image-compression": "^2.0.2",
     "@aws-sdk/client-s3": "^3.1018.0",
     "@hookform/resolvers": "^3.10.0",

--- a/app/prisma/migrations/20260619000000_remove_unused_auth_adapter_tables/migration.sql
+++ b/app/prisma/migrations/20260619000000_remove_unused_auth_adapter_tables/migration.sql
@@ -1,0 +1,6 @@
+-- Credentials auth uses JWT sessions only, so the Auth.js adapter session and
+-- verification-token tables are unused and should not remain in the schema.
+ALTER TABLE IF EXISTS "verification_tokens" DROP CONSTRAINT IF EXISTS "verification_tokens_userId_fkey";
+
+DROP TABLE IF EXISTS "verification_tokens";
+DROP TABLE IF EXISTS "VerificationToken";

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -253,7 +253,6 @@ model User {
   rank               Rank?               @relation(fields: [rankId], references: [id])
   helpContributions  HelpContribution[]
   accounts           Account[]
-  sessions           Session[]
   wins               PostWinner[]        @relation("PostWinner")
   walletTransactions WalletTransaction[]
   contentFlags       ContentFlag[]       @relation("FlaggedBy")
@@ -280,25 +279,6 @@ model Account {
 
   @@unique([provider, providerAccountId])
   @@map("accounts")
-}
-
-model Session {
-  identifier String
-  token      String
-  expires    DateTime
-  user       User?    @relation(fields: [userId], references: [id])
-  userId     String?
-
-  @@unique([identifier, token])
-  @@map("verification_tokens")
-}
-
-model VerificationToken {
-  identifier String
-  token      String
-  expires    DateTime
-
-  @@id([identifier, token])
 }
 
 model Follow {

--- a/app/tests/api/auth-credentials.test.ts
+++ b/app/tests/api/auth-credentials.test.ts
@@ -8,10 +8,6 @@ vi.mock("@/lib/wallet-auth", () => ({
   authenticateWalletWithChallenge: mockAuthenticateWalletWithChallenge,
 }));
 
-vi.mock("@auth/prisma-adapter", () => ({
-  PrismaAdapter: vi.fn().mockReturnValue({}),
-}));
-
 const VALID_WALLET_ADDRESS =
   "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 

--- a/app/tests/api/auth-js-smoke.test.ts
+++ b/app/tests/api/auth-js-smoke.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { POST as logout } from "@/app/(auth)/logout/route";
+import { authConfig } from "@/lib/auth-config";
+
+const mockAuthenticateWalletWithChallenge = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/wallet-auth", () => ({
+  authenticateWalletWithChallenge: mockAuthenticateWalletWithChallenge,
+}));
+
+const VALID_WALLET_ADDRESS =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+describe("Auth.js JWT credentials smoke flow", () => {
+  it("signs in through credentials without a database adapter session", async () => {
+    expect(authConfig).not.toHaveProperty("adapter");
+    expect(authConfig.session?.strategy).toBe("jwt");
+
+    mockAuthenticateWalletWithChallenge.mockResolvedValue({
+      success: true,
+      user: {
+        id: "user_1",
+        walletAddress: VALID_WALLET_ADDRESS,
+        username: "alice",
+        name: "alice",
+        email: "alice@example.com",
+        avatarUrl: null,
+        bio: null,
+        createdAt: new Date("2026-06-19T00:00:00.000Z"),
+      },
+    });
+
+    const authorize = (authConfig.providers[0] as any).options.authorize;
+    const user = await authorize({
+      walletAddress: VALID_WALLET_ADDRESS,
+      transaction: "signed-xdr",
+    });
+
+    expect(user).toMatchObject({
+      id: "user_1",
+      walletAddress: VALID_WALLET_ADDRESS,
+      username: "alice",
+      email: "alice@example.com",
+    });
+
+    const token = await authConfig.callbacks?.jwt?.({
+      token: {},
+      user,
+      account: null,
+      profile: undefined,
+      trigger: "signIn",
+      isNewUser: false,
+    } as any);
+
+    const session = await authConfig.callbacks?.session?.({
+      session: { user: {}, expires: new Date("2026-07-19T00:00:00.000Z").toISOString() },
+      token,
+      user,
+      newSession: undefined,
+      trigger: "update",
+    } as any);
+
+    expect(session?.user).toEqual({
+      id: "user_1",
+      walletAddress: VALID_WALLET_ADDRESS,
+      username: "alice",
+    });
+  });
+
+  it("signs out by clearing Auth.js JWT session cookies", async () => {
+    const response = await logout(
+      new NextRequest("http://localhost/api/auth/logout", { method: "POST" }),
+    );
+    const cookies = response.cookies.getAll();
+
+    expect(cookies).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "next-auth.session-token",
+          value: "",
+          maxAge: 0,
+        }),
+        expect.objectContaining({
+          name: "__Secure-next-auth.session-token",
+          value: "",
+          maxAge: 0,
+        }),
+      ]),
+    );
+  });
+});

--- a/app/tests/api/auth.test.ts
+++ b/app/tests/api/auth.test.ts
@@ -85,7 +85,6 @@ describe('GET /api/auth/me', () => {
         followers: 6,
         helpContributions: 0,
         accounts: 1,
-        sessions: 1,
       },
     };
 
@@ -124,7 +123,6 @@ describe('GET /api/auth/me', () => {
         followers: 0,
         helpContributions: 0,
         accounts: 1,
-        sessions: 1,
       },
     };
 
@@ -161,7 +159,6 @@ describe('GET /api/auth/me', () => {
         followers: 0,
         helpContributions: 0,
         accounts: 1,
-        sessions: 1,
       },
     };
 


### PR DESCRIPTION
closes #344 

## Summary
- remove the unused Prisma adapter from the Credentials/JWT Auth.js config
- remove malformed unused Session and VerificationToken Prisma models and add a migration to drop the stale token tables
- remove stale session-count selections and add JWT credentials sign-in/sign-out smoke coverage

## Verification
- DATABASE_URL='postgresql://user:pass@localhost:5432/geev_test' pnpm -C app exec prisma validate --schema prisma/schema.prisma
- pnpm -C app test
- pnpm -C app lint
- git diff --check

Note: pnpm -C app exec tsc --noEmit still reports existing unrelated test typing issues in entries.test.ts and post-slug-generation.test.ts.