### PR TITLE
fix: enforce authentication for indexer and cron endpoints

### DIFF
--- a/app/app/api/cron/expire-posts/route.ts
+++ b/app/app/api/cron/expire-posts/route.ts
@@ -4,9 +4,6 @@ import { prisma } from "@/lib/prisma";
 import { NextRequest } from "next/server";
 
 function isAuthorizedCron(request: NextRequest): boolean {
-  if (request.headers.get("x-vercel-cron") === "1") {
-    return true;
-  }
   const secret = process.env.CRON_SECRET;
   if (!secret) {
     return false;

--- a/app/app/api/cron/indexer/route.ts
+++ b/app/app/api/cron/indexer/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const authHeader = request.headers.get("authorization");
     const cronSecret = process.env.CRON_SECRET;
 
-    if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/app/app/api/indexer/route.ts
+++ b/app/app/api/indexer/route.ts
@@ -8,26 +8,20 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { runIndexerOnce, getIndexerStats, resetIndexerState } from "@/lib/indexer";
-import { auth } from "@/lib/auth";
+import { getCurrentAdmin } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 /**
  * POST handler - Trigger indexer run
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    // Check authentication for reset action
-    const session = await auth();
+    const admin = await getCurrentAdmin();
+    if (!admin) return apiError("Forbidden", 403);
+
     const body = await request.json().catch(() => ({}));
     
     if (body.action === "reset") {
-      // Only admins can reset
-      if (!session?.user) {
-        return NextResponse.json(
-          { error: "Unauthorized" },
-          { status: 401 }
-        );
-      }
-      
       await resetIndexerState(body.startLedger);
       return NextResponse.json({
         success: true,
@@ -36,7 +30,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       });
     }
 
-    // Run indexer once
     await runIndexerOnce();
     
     return NextResponse.json({
@@ -60,6 +53,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
  */
 export async function GET(): Promise<NextResponse> {
   try {
+    const admin = await getCurrentAdmin();
+    if (!admin) return apiError("Forbidden", 403);
+
     const stats = await getIndexerStats();
     
     return NextResponse.json({

--- a/app/tests/api/cron-expire-posts.test.ts
+++ b/app/tests/api/cron-expire-posts.test.ts
@@ -13,24 +13,26 @@ describe("GET /api/cron/expire-posts", () => {
     } as Awaited<ReturnType<typeof notifications.createNotification>>);
   });
 
-  it("returns 401 without Vercel cron header or bearer secret", async () => {
+  it("returns 401 when CRON_SECRET is unset (fail closed)", async () => {
     const request = createMockRequest("http://localhost:3000/api/cron/expire-posts");
     const response = await GET(request);
     expect(response.status).toBe(401);
   });
 
-  it("allows Vercel cron header without CRON_SECRET", async () => {
-    prisma.post.findMany = vi.fn().mockResolvedValue([]);
-    prisma.post.updateMany = vi.fn().mockResolvedValue({ count: 0 });
-
+  it("returns 401 with spoofed x-vercel-cron header when CRON_SECRET is unset", async () => {
     const request = createMockRequest("http://localhost:3000/api/cron/expire-posts", {
       headers: { "x-vercel-cron": "1" },
     });
     const response = await GET(request);
-    const { status, data } = await parseResponse(response);
-    expect(status).toBe(200);
-    expect(data.success).toBe(true);
-    expect(data.data.expired).toBe(0);
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 when authorization header is missing", async () => {
+    process.env.CRON_SECRET = "test-secret";
+
+    const request = createMockRequest("http://localhost:3000/api/cron/expire-posts");
+    const response = await GET(request);
+    expect(response.status).toBe(401);
   });
 
   it("expires open posts and notifies creators with bearer token", async () => {

--- a/app/tests/api/cron-indexer.test.ts
+++ b/app/tests/api/cron-indexer.test.ts
@@ -1,0 +1,67 @@
+import { GET } from "@/app/api/cron/indexer/route";
+import { createMockRequest, parseResponse } from "../helpers/api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRunIndexerOnce = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/indexer", () => ({
+  runIndexerOnce: mockRunIndexerOnce,
+}));
+
+describe("GET /api/cron/indexer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 401 when CRON_SECRET is unset (fail closed)", async () => {
+    const request = createMockRequest("http://localhost:3000/api/cron/indexer");
+    const response = await GET(request);
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+    expect(mockRunIndexerOnce).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when authorization header is missing", async () => {
+    process.env.CRON_SECRET = "test-secret";
+
+    const request = createMockRequest("http://localhost:3000/api/cron/indexer");
+    const response = await GET(request);
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+    expect(mockRunIndexerOnce).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when authorization header is wrong", async () => {
+    process.env.CRON_SECRET = "test-secret";
+
+    const request = createMockRequest("http://localhost:3000/api/cron/indexer", {
+      headers: { authorization: "Bearer wrong-secret" },
+    });
+    const response = await GET(request);
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+    expect(mockRunIndexerOnce).not.toHaveBeenCalled();
+  });
+
+  it("runs indexer when authorized with correct bearer token", async () => {
+    process.env.CRON_SECRET = "test-secret";
+    mockRunIndexerOnce.mockResolvedValue(undefined);
+
+    const request = createMockRequest("http://localhost:3000/api/cron/indexer", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+    const response = await GET(request);
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockRunIndexerOnce).toHaveBeenCalledOnce();
+  });
+});

--- a/app/tests/api/indexer.test.ts
+++ b/app/tests/api/indexer.test.ts
@@ -1,0 +1,126 @@
+import { GET, POST } from "@/app/api/indexer/route";
+import { createMockRequest, parseResponse } from "../helpers/api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentAdmin = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentAdmin: mockGetCurrentAdmin,
+}));
+
+const mockRunIndexerOnce = vi.hoisted(() => vi.fn());
+const mockGetIndexerStats = vi.hoisted(() => vi.fn());
+const mockResetIndexerState = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/indexer", () => ({
+  runIndexerOnce: mockRunIndexerOnce,
+  getIndexerStats: mockGetIndexerStats,
+  resetIndexerState: mockResetIndexerState,
+}));
+
+describe("POST /api/indexer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 for unauthenticated callers", async () => {
+    mockGetCurrentAdmin.mockResolvedValue(null);
+
+    const response = await POST(
+      createMockRequest("http://localhost:3000/api/indexer", {
+        method: "POST",
+        body: {},
+      }),
+    );
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(403);
+    expect(data.error).toBe("Forbidden");
+    expect(mockRunIndexerOnce).not.toHaveBeenCalled();
+  });
+
+  // Non-admin callers are also rejected — getCurrentAdmin returns null for them
+
+  it("runs indexer for admin callers", async () => {
+    mockGetCurrentAdmin.mockResolvedValue({
+      id: "admin_123",
+      name: "Admin",
+      role: "admin",
+    });
+    mockRunIndexerOnce.mockResolvedValue(undefined);
+
+    const response = await POST(
+      createMockRequest("http://localhost:3000/api/indexer", {
+        method: "POST",
+        body: {},
+      }),
+    );
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockRunIndexerOnce).toHaveBeenCalledOnce();
+  });
+
+  it("resets indexer state for admin callers with action=reset", async () => {
+    mockGetCurrentAdmin.mockResolvedValue({
+      id: "admin_123",
+      name: "Admin",
+      role: "admin",
+    });
+    mockResetIndexerState.mockResolvedValue(undefined);
+
+    const response = await POST(
+      createMockRequest("http://localhost:3000/api/indexer", {
+        method: "POST",
+        body: { action: "reset", startLedger: 12345 },
+      }),
+    );
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.message).toBe("Indexer state reset");
+    expect(mockResetIndexerState).toHaveBeenCalledWith(12345);
+    expect(mockRunIndexerOnce).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/indexer/stats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 for unauthenticated callers", async () => {
+    mockGetCurrentAdmin.mockResolvedValue(null);
+
+    const response = await GET(
+      createMockRequest("http://localhost:3000/api/indexer/stats"),
+    );
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(403);
+    expect(data.error).toBe("Forbidden");
+  });
+
+  it("returns stats for admin callers", async () => {
+    mockGetCurrentAdmin.mockResolvedValue({
+      id: "admin_123",
+      name: "Admin",
+      role: "admin",
+    });
+    mockGetIndexerStats.mockResolvedValue({
+      lastLedger: 12345,
+      status: "synced",
+    });
+
+    const response = await GET(
+      createMockRequest("http://localhost:3000/api/indexer/stats"),
+    );
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toEqual({ lastLedger: 12345, status: "synced" });
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## Description

Closes #352

### Route fixes
1. app/app/api/indexer/route.ts — Both POST (run + reset) and GET (stats) now call getCurrentAdmin() upfront. Non-admin/anonymous callers get 403. Removed the old auth() check for reset that only verified any session existed.
2. app/app/api/cron/indexer/route.ts — Changed the CRON_SECRET check from if (cronSecret && authHeader !== ...) (fails open) to if (!cronSecret || authHeader !== ...) (fails closed). Without CRON_SECRET set, all requests are rejected with 401.
3. app/app/api/cron/expire-posts/route.ts — Removed the x-vercel-cron: 1 bypass from isAuthorizedCron(). Now only Authorization: Bearer ${CRON_SECRET} is accepted. Fails closed when CRON_SECRET is unset.

### Tests
- app/tests/api/indexer.test.ts (new) — 5 tests: unauthenticated POST→403, admin POST→runs indexer, admin POST (reset)→resets state, unauthenticated GET→403, admin GET→returns stats.
- app/tests/api/cron-indexer.test.ts (new) — 4 tests: CRON_SECRET unset→401, missing auth header→401, wrong secret→401, correct bearer token→200.
- app/tests/api/cron-expire-posts.test.ts (updated) — Removed the x-vercel-cron bypass test, added fail-closed and missing auth header tests (4 total).
---

## Checklist
- [ ] I have tested my changes locally
- [ ] I have updated documentation as needed
- [ ] I have run `npx prisma generate` after schema changes
- [ ] I have run `npx prisma migrate dev` or `npx prisma migrate deploy` as appropriate

---

## Post-Merge Steps for Maintainers

**If this PR includes changes to the Prisma schema:**

1. Run the following command to apply the migration to your database:
   
   ```sh
   npx prisma migrate deploy
   ```
   or, for local development:
   ```sh
   npx prisma migrate dev
   ```
2. Ensure your CI pipeline runs the migration before tests (add this step if missing):
   ```yaml
   - name: Run Prisma Migrate
     run: npx prisma migrate deploy
   ```
3. Make sure the database user in CI has permission to run migrations.

---

If you have any questions, please comment on this PR.
