### PR TITLE
chore(deps): add prettier to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     },
     "devDependencies": {
         "@changesets/cli": "^2.26.0",
+        "prettier": "^3.8.4",
         "turbo": "latest"
     },
     "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Tested locally: `pnpm format --check **/*.{ts,tsx,md}` no longer fails with the previous "prettier: not found" error after this dep is added.