### PR TITLE
chore(sec): add dependabot + codeql configs (admin toggles required in Settings)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot configuration.
+#
+# This file configures the cadence and grouping of Dependabot pull requests
+# (npm version updates, GitHub Actions version updates). It does NOT
+# by itself enable Dependabot security alerts — that Settings toggle must be
+# flipped under:
+#
+#   `https://github.com/geevapp/geev/settings/security_analysis`
+#
+# Once a maintainer enables Dependabot (alerts + version updates + security
+# updates) the settings below will begin producing PRs.
+#
+# Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 8
+    groups:
+      app-minor-and-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "app"
+      - "area: app"
+    commit-message:
+      prefix: "chore(deps)"
+    # Auto-rebase once conflicts appear so we don't accumulate stale PRs.
+    rebase-strategy: "auto"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+    rebase-strategy: "auto"
+
+# NOTE: The `contracts/` Cargo workspace is not currently covered by this
+# config because Dependabot does not yet ship robust first-class cargo
+# support. We will add a `cargo audit` (and ideally `cargo update` review)
+# CI workflow in a separate follow-up — see SECURITY.md "Supply Chain".

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,63 @@
+name: "CodeQL Analysis"
+
+# Triggers:
+#  - On every push to `main`
+#  - On every PR targeting `main`
+#  - Weekly schedule (matches GitHub-default CodeQL cadence)
+#
+# NOTE: Code Scanning itself must be enabled at the repo level by a
+# maintainer under `Settings → Code security and analysis → Code scanning`.
+# Until then, this workflow will run but SARIF uploads will not surface
+# alerts in the Security tab. The configure-side has a "Default setup"
+# option that picks this file up automatically.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Every Monday at 06:17 UTC.
+    - cron: "17 6 * * 1"
+
+# Minimal permissions — CodeQL only needs to write security events and
+# read repo contents. This narrows the workflow's blast radius.
+permissions:
+  security-events: write
+  contents: read
+  # Avoid elevating to write-all; don't grant packages / actions / id-token
+  # by default.
+
+jobs:
+  analyze:
+    name: "Analyze (${{ matrix.language }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # The Next.js app lives in `app/`. Rust (Soroban) contracts are
+        # analyzed separately via Cargo + clippy in the existing
+        # `.github/workflows/rust.yml` workflow; CodeQL doesn't analyze
+        # Rust directly here, so we keep this matrix narrow.
+        language: ["javascript-typescript"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # Use the bundled "security-and-quality" query pack — covers the
+          # default OWASP/CWE categories without writing our own packs.
+          queries: security-and-quality
+          # JS/TS analysis runs without explicit build because CodeQL
+          # can drive its own extraction. If adding C/C++ or Go later,
+          # switch this back to "autobuild".
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

This PR adds the code-level pieces of the GitHub-side hardening referenced in SECURITY.md ("GitHub-Side Hardening" section). The contributing token on `geevapp/geev` is `pull: true` only (no admin / push), so the actual feature toggles cannot be flipped via API — they must be enabled by a maintainer under repo Settings once this PR merges.

## Changes

- **`.github/dependabot.yml`** — Dependabot version updates for the `app/` npm workspace and for GitHub Actions at the repo root. Weekly cadence, group minor/patch to reduce PR noise, conventional-commits prefix, auto-rebase. Cargo / `contracts/` workspace intentionally not covered (no first-class Dependabot support for cargo today).
- **`.github/workflows/codeql.yml`** — CodeQL Analysis workflow for the Next.js `app/` workspace. Weekly cron + on-push-to-main + on-PR-to-main triggers, least-privilege permissions (`security-events: write`, `contents: read`), `queries: security-and-quality`, `build-mode: none` (JS/TS only).

Reviewer feedback has been incorporated — `area: app` label was kept (Dependabot gracefully skips unknown labels) and CodeQL action is pinned to `@v3` major (locking to commit hashes can come in a follow-up via Dependabot itself).

## Maintainer Action Required

Settings → Code security and analysis (admin-only):

| Feature | Status before this PR | Toggle |
| --- | --- | --- |
| Dependabot security alerts | disabled (probe returned 403) | Enable |
| Dependabot version updates | disabled | Enable (will pick up `.github/dependabot.yml`) |
| Code scanning (CodeQL) | disabled | "Default setup" picks up the new workflow automatically |
| Secret scanning | not enabled | Enable |
| Push protection (secrets) | not enabled | Enable |
| Private vulnerability reporting | API returned `enabled: false` | Enable |

After enabling:
- `pnpm audit` / `cargo audit` should start informing Dependabot PRs.
- `CodeQL Analysis` workflow will begin posting SARIF runs into the Security tab.
- `gh api /repos/geevapp/geev/vulnerability-alerts` will return 200 once alerts are on.

## Out of scope (intentional follow-ups)

- A `cargo audit` workflow for the `contracts/` workspace — Dependabot does not cover Cargo reliably today; we will add a separate CI job.
- Pinning CodeQL action to commit hashes (let Dependabot drive that through its own GH Actions updates).

## Test / verify

No automated test for this PR — code-land is config files only. After Settings toggles are on, expect dependabot.yml + codeql workflow to fire Monday morning (or sooner if manually triggered).