### PR TITLE
ci(sec): add supply-chain security audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,68 @@
+name: Supply-Chain Security Audit
+
+# This workflow enforces two supply-chain hygiene checks described in
+# SECURITY.md ("npm / pnpm Supply Chain"):
+#
+#   1. `pnpm install --frozen-lockfile` — fails if the lockfile has drifted
+#      from `package.json` / `app/package.json` (i.e. someone bumped a dep
+#      without regenerating the lockfile, OR regenerated it in a way the
+#      repo didn't accept).
+#   2. `pnpm audit --prod --audit-level=high` — fails if any *production*
+#      dependency (excluding devDependencies) has a known high or critical
+#      CVE in the GitHub Advisory Database.
+#
+# Triggers on every PR to `main` and on manual dispatch (for ad-hoc checks).
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+# Permissions intentionally narrow: this workflow only reads.
+permissions:
+  contents: read
+
+jobs:
+  pnpm-audit:
+    name: pnpm audit (frozen lockfile + high/critical CVEs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # pnpm v10 default timezone
+      TZ: UTC
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          # Pin a major rather than a full version so floating patches still
+          # apply. Adjust if the project moves to a different pnpm major.
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      # The repo's `.gitignore` currently excludes `pnpm-lock.yaml`, so the
+      # strict frozen-lockfile check is gated on whether the file actually
+      # exists in the working tree. Once the maintainer un-ignores the
+      # lockfile and commits it, this `if:` flips to the strict check
+      # automatically without further edits to the workflow.
+      - name: Install with frozen lockfile (strict — only when committed)
+        if: hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm install --frozen-lockfile
+
+      - name: Install (lockfile not committed yet — soft warning)
+        if: hashFiles('pnpm-lock.yaml') == ''
+        run: |
+          echo "::warning::pnpm-lock.yaml is not committed; falling back to a non-frozen install. Un-ignore the lockfile in .gitignore and commit it to enable the strict frozen-lockfile check."
+          pnpm install
+
+      # `--audit-level=high` makes pnpm exit non-zero on ANY high-severity
+      # OR critical finding in the audited tree. `--prod` skips
+      # devDependencies (test tooling, lints, etc.).
+      - name: Audit production deps (fail on high / critical)
+        run: pnpm audit --prod --audit-level=high


### PR DESCRIPTION
## Summary

Adds `.github/workflows/security-audit.yml`, a CI workflow that runs two supply-chain hygiene checks (per the SECURITY.md "npm / pnpm Supply Chain" section) on every PR to `main` and on `workflow_dispatch`:

1. **`pnpm install --frozen-lockfile`** — surfaces #NOT-IN-LOCKFILE failures whenever a transitive dep was added without regenerating the lockfile. This step is gated on `hashFiles(pnpm-lock.yaml) != ""` because the repo currently gitignores the lockfile; until a follow-up removes that line, the workflow falls back to a soft-warning plain `pnpm install` so PRs aren't blocked.
2. **`pnpm audit --prod --audit-level=high`** — exits non-zero if any production dep carries a known high-severity or critical CVE in the GitHub Advisory Database.

Permissions are `contents: read` only.

Reviewer feedback was integrated: the lockfile step is now conditional on `hashFiles(pnpm-lock.yaml) != ""` so the workflow survives the current `.gitignore` policy without blocking PRs. The strict check will flip on automatically the moment a maintainer un-ignores + commits `pnpm-lock.yaml`.

## Active today vs. after the lockfile follow-up

| Lockfile state | What runs |
| --- | --- |
| Currently (gitignored) | `pnpm install` + soft `::warning::` + `pnpm audit --prod --audit-level=high`. Audit gates PRs; lockfile drift is unmonitored. |
| After maintainer un-ignores + commits `pnpm-lock.yaml` | `pnpm install --frozen-lockfile` (strict) + audit. Both gate PRs. |

## Follow-ups (intentionally out of scope here)

- Remove the `pnpm-lock.yaml` line from `.gitignore` and commit the current lockfile so the strict lockfile step becomes active.
- Add a `paths:` filter (`["app/**", "package.json", ".github/dependabot.yml"]`) so contract-only Rust PRs do not waste CI minutes on `npm audit`.
- Capture `pnpm audit --json` and `upload-sarif` to GitHub Code Scanning so findings surface in the Security tab alongside CodeQL.
- Add a weekly `schedule:` trigger so freshly-published CVEs are caught between PRs.
- Pin `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` to commit hashes (per SECURITY.md recommendations).
- Add a parallel `cargo audit` workflow for the `contracts/` workspace (Cargo is not covered by Dependabot reliably today).

## Test / verify

After merge, open any PR; the workflow will appear in the Checks tab. While the lockfile is gitignored, expect a yellow `::warning::` annotation on the install step but a green overall pass on the audit step (assuming no current high/critical CVEs).