### PR TITLE
Fix: Add currentAmount aggregation to posts list API for help-request progress

### DIFF
--- a/app/app/api/posts/route.ts
+++ b/app/app/api/posts/route.ts
@@ -288,7 +288,29 @@ const GET = async (request: NextRequest) => {
       prisma.post.count({ where }),
     ]);
 
-    return apiSuccess({ posts, page, limit, total });
+    const postIds = posts.map((p: { id: string }) => p.id);
+    const contributionAggregates =
+      postIds.length > 0
+        ? await prisma.helpContribution.groupBy({
+            by: ["postId"],
+            where: { postId: { in: postIds } },
+            _sum: { amount: true },
+          })
+        : [];
+
+    const contributionMap = new Map<string, number>(
+      contributionAggregates.map((agg: { postId: string; _sum: { amount: number | null } }) => [
+        agg.postId,
+        agg._sum.amount ?? 0,
+      ]),
+    );
+
+    const postsWithCurrentAmount = posts.map((post: { id: string }) => ({
+      ...post,
+      currentAmount: contributionMap.get(post.id) ?? 0,
+    }));
+
+    return apiSuccess({ posts: postsWithCurrentAmount, page, limit, total });
   } catch (error) {
     return apiError("Failed to fetch posts", 500);
   }

--- a/app/lib/map-api-post.ts
+++ b/app/lib/map-api-post.ts
@@ -40,6 +40,7 @@ export function mapApiPostToClientPost(apiPost: Record<string, unknown> | null |
       (apiPost.entriesCount as number) ??
       (typeof _count?.entries === "number" ? _count.entries : 0) ??
       (Array.isArray(apiPost.entries) ? apiPost.entries.length : 0),
+    currentAmount: (apiPost.currentAmount as number | undefined) ?? 0,
     author: {
       id: (user?.id as string) ?? (apiPost.userId as string) ?? "",
       name: (user?.name as string) ?? "Unknown User",

--- a/app/tests/api/posts.test.ts
+++ b/app/tests/api/posts.test.ts
@@ -180,6 +180,34 @@ describe("Posts API", () => {
       );
     });
 
+    it("should return currentAmount as sum of helpContributions for each post", async () => {
+      prisma.post.findMany = vi.fn().mockResolvedValue([
+        { id: "post_help_1", title: "Help Request Post", type: "request", user: testUser },
+        { id: "post_help_2", title: "Another Help Post", type: "request", user: testUser },
+        { id: "post_no_contrib", title: "No Contributions Post", type: "request", user: testUser },
+      ]);
+      prisma.post.count = vi.fn().mockResolvedValue(3);
+      (prisma.helpContribution as any).groupBy = vi.fn().mockResolvedValue([
+        { postId: "post_help_1", _sum: { amount: 1250 } },
+        { postId: "post_help_2", _sum: { amount: 300 } },
+      ]);
+
+      const request = createMockRequest("http://localhost:3000/api/posts?type=request");
+      const response = await GET(request);
+      const { status, data } = await parseResponse(response);
+
+      expect(status).toBe(200);
+      expect(data.data.posts).toHaveLength(3);
+
+      const post1 = data.data.posts.find((p: any) => p.id === "post_help_1");
+      const post2 = data.data.posts.find((p: any) => p.id === "post_help_2");
+      const post3 = data.data.posts.find((p: any) => p.id === "post_no_contrib");
+
+      expect(post1.currentAmount).toBe(1250);
+      expect(post2.currentAmount).toBe(300);
+      expect(post3.currentAmount).toBe(0);
+    });
+
     it("applies deadline active filter when filter=active", async () => {
       prisma.post.findMany = vi.fn().mockResolvedValue([]);
       prisma.post.count = vi.fn().mockResolvedValue(0);


### PR DESCRIPTION
Closes #355

## Summary
- Added a single `helpContribution.groupBy(_sum: amount)` call to the `GET /api/posts` endpoint, efficiently aggregating raised amounts for all returned posts in one query
- Each post in the response now includes `currentAmount` (total raised), defaulting to `0` when no contributions exist
- Updated `mapApiPostToClientPost` to explicitly map `currentAmount` so the client `Post` shape is always populated
- Added a unit test verifying the aggregation and zero-fallback behaviour

## Test plan
- [ ] Run `vitest run tests/api/posts.test.ts` — all tests pass including the new `currentAmount` test
- [ ] Open the feed — help-request posts now display the correct "$X raised" amount and progress bar percentage
- [ ] ContributionForm remaining calculation uses the correct `currentAmount` from the list response