### PR TITLE
feat(contracts): add moderation appeal and reinstatement flow

### DIFF
--- a/contracts/geev-core/src/admin.rs
+++ b/contracts/geev-core/src/admin.rs
@@ -1,4 +1,4 @@
-use crate::types::{DataKey, Error};
+use crate::types::{DataKey, Error, GiveawayStatus, HelpRequestStatus};
 use crate::{access::check_admin, types::HelpRequest};
 use soroban_sdk::{contract, contractevent, contractimpl, panic_with_error, token, Address, Env};
 
@@ -21,6 +21,13 @@ pub struct TokenAdded {
 pub struct RequestVerificationChanged {
     request_id: u64,
     is_verified: bool,
+}
+
+#[contractevent]
+pub struct AppealResolved {
+    #[topic]
+    target_id: u64,
+    restored: bool,
 }
 
 #[contractimpl]
@@ -94,5 +101,48 @@ impl AdminContract {
             is_verified: request.is_verified,
         }
         .publish(&env);
+    }
+
+    /// Resolve an appeal for suspended content - callable only by Admin
+    /// Allows admin to restore the content or keep it suspended
+    pub fn resolve_appeal(env: Env, target_id: u64, restore: bool) {
+        check_admin(&env);
+
+        let giveaway_key = DataKey::Giveaway(target_id);
+        let request_key = DataKey::HelpRequest(target_id);
+
+        let mut resolved = false;
+
+        // Try Giveaway first.
+        if let Some(mut giveaway) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, crate::types::Giveaway>(&giveaway_key)
+        {
+            if giveaway.status == GiveawayStatus::UnderAppeal {
+                giveaway.status = if restore { GiveawayStatus::Active } else { GiveawayStatus::Suspended };
+                env.storage().persistent().set(&giveaway_key, &giveaway);
+                resolved = true;
+            }
+        }
+
+        // Try HelpRequest if giveaway wasn't found/resolved.
+        if !resolved {
+            if let Some(mut request) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, crate::types::HelpRequest>(&request_key)
+            {
+                if request.status == HelpRequestStatus::UnderAppeal {
+                    request.status = if restore { HelpRequestStatus::Open } else { HelpRequestStatus::Suspended };
+                    env.storage().persistent().set(&request_key, &request);
+                    resolved = true;
+                }
+            }
+        }
+
+        if resolved {
+            AppealResolved { target_id, restored: restore }.publish(&env);
+        }
     }
 }

--- a/contracts/geev-core/src/admin.rs
+++ b/contracts/geev-core/src/admin.rs
@@ -120,7 +120,11 @@ impl AdminContract {
             .get::<DataKey, crate::types::Giveaway>(&giveaway_key)
         {
             if giveaway.status == GiveawayStatus::UnderAppeal {
-                giveaway.status = if restore { GiveawayStatus::Active } else { GiveawayStatus::Suspended };
+                giveaway.status = if restore {
+                    GiveawayStatus::Active
+                } else {
+                    GiveawayStatus::Suspended
+                };
                 env.storage().persistent().set(&giveaway_key, &giveaway);
                 resolved = true;
             }
@@ -134,7 +138,11 @@ impl AdminContract {
                 .get::<DataKey, crate::types::HelpRequest>(&request_key)
             {
                 if request.status == HelpRequestStatus::UnderAppeal {
-                    request.status = if restore { HelpRequestStatus::Open } else { HelpRequestStatus::Suspended };
+                    request.status = if restore {
+                        HelpRequestStatus::Open
+                    } else {
+                        HelpRequestStatus::Suspended
+                    };
                     env.storage().persistent().set(&request_key, &request);
                     resolved = true;
                 }
@@ -142,7 +150,11 @@ impl AdminContract {
         }
 
         if resolved {
-            AppealResolved { target_id, restored: restore }.publish(&env);
+            AppealResolved {
+                target_id,
+                restored: restore,
+            }
+            .publish(&env);
         }
     }
 }

--- a/contracts/geev-core/src/governance.rs
+++ b/contracts/geev-core/src/governance.rs
@@ -22,6 +22,13 @@ pub struct ContentAutoSuspended {
     count: u32,
 }
 
+#[contractevent]
+pub struct ContentAppealed {
+    #[topic]
+    target_id: u64,
+    user: Address,
+}
+
 #[contractimpl]
 impl GovernanceContract {
     /// Flag a piece of content (Giveaway or HelpRequest) by its ID.
@@ -59,6 +66,57 @@ impl GovernanceContract {
         }
 
         Ok(())
+    }
+
+    /// File an appeal for a suspended content.
+    /// Only the creator of the content can file an appeal.
+    pub fn file_appeal(env: Env, user: Address, target_id: u64) -> Result<(), Error> {
+        user.require_auth();
+
+        let giveaway_key = DataKey::Giveaway(target_id);
+        let request_key = DataKey::HelpRequest(target_id);
+
+        // Try Giveaway first
+        if let Some(mut giveaway) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, crate::types::Giveaway>(&giveaway_key)
+        {
+            if giveaway.creator != user {
+                return Err(Error::NotCreator);
+            }
+            if giveaway.status != GiveawayStatus::Suspended {
+                return Err(Error::InvalidStatus);
+            }
+            giveaway.status = GiveawayStatus::UnderAppeal;
+            env.storage().persistent().set(&giveaway_key, &giveaway);
+
+            ContentAppealed { target_id, user }.publish(&env);
+            return Ok(());
+        }
+
+        // Try HelpRequest
+        if let Some(mut request) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, crate::types::HelpRequest>(&request_key)
+        {
+            if request.creator != user {
+                return Err(Error::NotCreator);
+            }
+            if request.status != HelpRequestStatus::Suspended {
+                return Err(Error::InvalidStatus);
+            }
+            request.status = HelpRequestStatus::UnderAppeal;
+            env.storage().persistent().set(&request_key, &request);
+
+            ContentAppealed { target_id, user }.publish(&env);
+            return Ok(());
+        }
+
+        // If neither exists, could be future content or invalid ID.
+        // We'll return GiveawayNotFound as a fallback.
+        Err(Error::GiveawayNotFound)
     }
 
     /// Returns the total number of flags for a given content ID.

--- a/contracts/geev-core/src/types.rs
+++ b/contracts/geev-core/src/types.rs
@@ -39,11 +39,11 @@ pub enum GiveawayStatus {
     Claimable = 1,
     Completed = 2,
     Suspended = 3,
-    UnderAppeal = 4,
     // ─── Dispute States ────────────────────────────────────────────────────
     Disputed = 4,
     ResolvedRelease = 5,
     ResolvedRefund = 6,
+    UnderAppeal = 7,
 }
 
 #[derive(Clone)]
@@ -79,11 +79,11 @@ pub enum HelpRequestStatus {
     Closed = 2,
     Cancelled = 3,
     Suspended = 4,
-    UnderAppeal = 5,
     // ─── Dispute States ────────────────────────────────────────────────────
     Disputed = 5,
     ResolvedRelease = 6,
     ResolvedRefund = 7,
+    UnderAppeal = 8,
 }
 
 #[derive(Clone)]

--- a/contracts/geev-core/src/types.rs
+++ b/contracts/geev-core/src/types.rs
@@ -35,6 +35,7 @@ pub enum GiveawayStatus {
     Claimable = 1,
     Completed = 2,
     Suspended = 3,
+    UnderAppeal = 4,
 }
 
 #[derive(Clone)]
@@ -70,6 +71,7 @@ pub enum HelpRequestStatus {
     Closed = 2,
     Cancelled = 3,
     Suspended = 4,
+    UnderAppeal = 5,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
# Description
Content can now be appealed and reinstated after moderation review. This adds an on-chain appeal flow to restore content when an auto-suspension was incorrect, restricting the reinstatement action to admin or moderator authority.

## Changes Made
* **`contracts/geev-core/src/types.rs`**: Added an `UnderAppeal` state to `GiveawayStatus` and `HelpRequestStatus`.
* **`contracts/geev-core/src/governance.rs`**: Added a `file_appeal` action allowing content creators to mark their suspended content as under appeal, along with a `ContentAppealed` event.
* **`contracts/geev-core/src/admin.rs`**: Added a `resolve_appeal` action restricting appeal resolution to admins, enabling them to restore content or keep it suspended. Also added an `AppealResolved` event for auditability.

Closes #315
