### PR TITLE
feat: global search & discovery page + harden pagination validation (#396, #358)

### DIFF
--- a/app/app/api/leaderboard/route.ts
+++ b/app/app/api/leaderboard/route.ts
@@ -2,18 +2,15 @@ import { apiError, apiSuccess } from '@/lib/api-response';
 
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { parsePagination } from '@/lib/pagination';
 
 export async function GET (request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const period = searchParams.get('period') || 'all-time';
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '50');
-
-    // Validate pagination parameters
-    if (page < 1 || limit < 1 || limit > 100) {
-      return apiError('Invalid pagination parameters', 400);
-    }
+    const { page, limit, skip } = parsePagination(searchParams, {
+      defaultLimit: 50,
+    });
 
     let dateFilter: Date | undefined;
     if (period === 'weekly') {
@@ -47,7 +44,7 @@ export async function GET (request: NextRequest) {
         xp: 'desc',
       },
       take: limit,
-      skip: (page - 1) * limit,
+      skip,
     });
 
     const tierOrder = { bronze: 1, silver: 2, gold: 3, platinum: 4 };

--- a/app/app/api/posts/[id]/comments/route.ts
+++ b/app/app/api/posts/[id]/comments/route.ts
@@ -4,6 +4,7 @@ import { apiSuccess, apiError } from "@/lib/api-response";
 import { getCurrentUser } from "@/lib/auth";
 import { readJsonBody } from "@/lib/parse-json-body";
 import { createNotification } from "@/lib/notifications";
+import { parsePagination } from "@/lib/pagination";
 
 export async function GET(
   request: NextRequest,
@@ -12,9 +13,9 @@ export async function GET(
   try {
     const { id } = await params;
     const { searchParams } = new URL(request.url);
-    const page = parseInt(searchParams.get("page") || "1");
-    const limit = parseInt(searchParams.get("limit") || "50");
-    const skip = (page - 1) * limit;
+    const { page, limit, skip } = parsePagination(searchParams, {
+      defaultLimit: 50,
+    });
 
     const [comments, total] = await Promise.all([
       prisma.comment.findMany({

--- a/app/app/api/posts/[id]/entries/route.ts
+++ b/app/app/api/posts/[id]/entries/route.ts
@@ -11,6 +11,7 @@ import {
   createNotificationInTransaction,
   fanOutNotificationsInTransaction,
 } from "@/lib/notifications";
+import { parsePagination } from "@/lib/pagination";
 
 function hasEntryProof(proofUrl: unknown, proofImage: unknown): boolean {
   const urlOk = typeof proofUrl === "string" && proofUrl.trim().length > 0;
@@ -303,14 +304,7 @@ export async function GET(
     const { id: postId } = await params;
     const { searchParams } = new URL(request.url);
 
-    const page = parseInt(searchParams.get("page") || "1");
-    const limit = parseInt(searchParams.get("limit") || "10");
-    const skip = (page - 1) * limit;
-
-    // Validate pagination params
-    if (page < 1 || limit < 1 || limit > 100) {
-      return apiError("Invalid pagination parameters", 400);
-    }
+    const { page, limit, skip } = parsePagination(searchParams);
 
     // Check if post exists
     const post = await prisma.post.findUnique({

--- a/app/app/api/posts/route.ts
+++ b/app/app/api/posts/route.ts
@@ -9,6 +9,7 @@ import { prisma } from "@/lib/prisma";
 import { readJsonBody } from "@/lib/parse-json-body";
 import { POST_SLUG_MAX_LENGTH, sanitizePostSlug } from "@/lib/post-slug";
 import { checkAndAwardBadges } from "@/lib/badges";
+import { parsePagination } from "@/lib/pagination";
 
 const SLUG_SUFFIX_LENGTH = 6;
 
@@ -215,8 +216,7 @@ const GET = async (request: NextRequest) => {
     const status = searchParams.get("status");
     const from = searchParams.get("from");
     const to = searchParams.get("to");
-    const page = parseInt(searchParams.get("page") || "1");
-    const limit = parseInt(searchParams.get("limit") || "10");
+    const { page, limit, skip } = parsePagination(searchParams);
 
     const where: Prisma.PostWhereInput = {};
     where.moderationStatus = { notIn: ["suspended", "banned"] };
@@ -266,7 +266,7 @@ const GET = async (request: NextRequest) => {
       prisma.post.findMany({
         where,
         orderBy,
-        skip: (page - 1) * limit,
+        skip,
         take: limit,
         include: {
           user: {

--- a/app/app/api/posts/route.ts
+++ b/app/app/api/posts/route.ts
@@ -210,6 +210,7 @@ const GET = async (request: NextRequest) => {
 
     const q = searchParams.get("q");
     const type = searchParams.get("type");
+    const category = searchParams.get("category");
     const sort = searchParams.get("sort");
     const filter = searchParams.get("filter");
     const userId = searchParams.get("userId");
@@ -234,6 +235,10 @@ const GET = async (request: NextRequest) => {
 
     if (type) {
       where.type = type as any;
+    }
+
+    if (category) {
+      where.category = category as any;
     }
 
     if (userId) {

--- a/app/app/api/users/[id]/followers/route.ts
+++ b/app/app/api/users/[id]/followers/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { apiSuccess, apiError } from "@/lib/api-response";
 import { getCurrentUser } from "@/lib/auth";
+import { parseOffsetPagination } from "@/lib/pagination";
 
 export async function GET(
   request: NextRequest,
@@ -10,8 +11,9 @@ export async function GET(
   try {
     const { id: targetUserId } = await params;
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get('limit') || '20');
-    const skip = parseInt(searchParams.get('skip') || '0');
+    const { limit, skip } = parseOffsetPagination(searchParams, {
+      defaultLimit: 20,
+    });
 
     const currentUser = await getCurrentUser(request);
 

--- a/app/app/api/users/[id]/following/route.ts
+++ b/app/app/api/users/[id]/following/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { apiSuccess, apiError } from "@/lib/api-response";
 import { getCurrentUser } from "@/lib/auth";
+import { parseOffsetPagination } from "@/lib/pagination";
 
 export async function GET(
   request: NextRequest,
@@ -10,8 +11,9 @@ export async function GET(
   try {
     const { id: targetUserId } = await params;
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get('limit') || '20');
-    const skip = parseInt(searchParams.get('skip') || '0');
+    const { limit, skip } = parseOffsetPagination(searchParams, {
+      defaultLimit: 20,
+    });
 
     const currentUser = await getCurrentUser(request);
 

--- a/app/app/search/page.tsx
+++ b/app/app/search/page.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Frown, Search, SlidersHorizontal, Users } from "lucide-react";
+import Link from "next/link";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import { PostCard } from "@/components/post-card";
+import { mapApiPostToClientPost } from "@/lib/map-api-post";
+import type { Post } from "@/lib/types";
+import {
+  buildPostsSearchQuery,
+  filterPeople,
+  hasActiveSearch,
+  POST_CATEGORIES,
+  SEARCH_SORTS,
+  SEARCH_TYPES,
+  type DiscoveryPerson,
+  type PostCategory,
+  type SearchSort,
+  type SearchType,
+} from "@/lib/search";
+
+const ALL_CATEGORIES = "all";
+
+function SearchSkeleton() {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="h-40 rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse"
+        />
+      ))}
+    </div>
+  );
+}
+
+function PersonCard({ person }: { person: DiscoveryPerson }) {
+  const initials = person.name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <Link href={`/profile/${person.id}`}>
+      <Card className="hover:shadow-md transition-shadow border-gray-100 dark:border-gray-800">
+        <CardContent className="flex items-center gap-3 p-4">
+          <Avatar className="h-11 w-11">
+            <AvatarImage src={person.avatar_url || "/placeholder.svg"} alt={person.name} />
+            <AvatarFallback>{initials || "?"}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="font-medium truncate">{person.name}</p>
+            {typeof person.xp === "number" && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {person.xp.toLocaleString()} XP
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function SearchView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [query, setQuery] = useState(() => searchParams.get("q") ?? "");
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+  const [type, setType] = useState<SearchType>(
+    () => (searchParams.get("type") as SearchType) || "all",
+  );
+  const [category, setCategory] = useState<PostCategory | "all">(ALL_CATEGORIES);
+  const [sort, setSort] = useState<SearchSort>("recent");
+  const [activeOnly, setActiveOnly] = useState(false);
+
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [people, setPeople] = useState<DiscoveryPerson[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Debounce the keyword so we don't fire a request on every keystroke.
+  useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedQuery(query), 400);
+    return () => clearTimeout(timeout);
+  }, [query]);
+
+  const filters = useMemo(
+    () => ({ q: debouncedQuery, type, category, sort, activeOnly }),
+    [debouncedQuery, type, category, sort, activeOnly],
+  );
+
+  // Keep the URL in sync so searches are shareable / bookmarkable.
+  useEffect(() => {
+    const queryString = buildPostsSearchQuery({ q: debouncedQuery, type });
+    router.replace(queryString ? `/search?${queryString}` : "/search", {
+      scroll: false,
+    });
+  }, [debouncedQuery, type, router]);
+
+  // Fetch matching posts whenever the filters change.
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadPosts = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const queryString = buildPostsSearchQuery({ ...filters, limit: 30 });
+        const res = await fetch(`/api/posts?${queryString}`, {
+          cache: "no-store",
+        });
+        if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+        const json = await res.json();
+        const rawList: Record<string, unknown>[] = json.data?.posts ?? [];
+        const mapped = rawList
+          .map((p) => mapApiPostToClientPost(p))
+          .filter(Boolean) as Post[];
+        if (!cancelled) setPosts(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load results");
+          setPosts([]);
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    loadPosts();
+    return () => {
+      cancelled = true;
+    };
+  }, [filters]);
+
+  // People discovery is powered by the leaderboard and filtered client-side.
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadPeople = async () => {
+      try {
+        const res = await fetch("/api/leaderboard?period=all-time&limit=50", {
+          cache: "no-store",
+        });
+        if (!res.ok) return;
+        const json = await res.json();
+        if (!cancelled) setPeople(json.data?.leaderboard ?? []);
+      } catch {
+        if (!cancelled) setPeople([]);
+      }
+    };
+
+    loadPeople();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const visiblePeople = useMemo(
+    () => filterPeople(people, debouncedQuery),
+    [people, debouncedQuery],
+  );
+
+  const searching = hasActiveSearch(filters);
+  const noResults = !isLoading && searching && posts.length === 0;
+  const idle = !isLoading && !searching && posts.length === 0;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const focusInput = useCallback(() => inputRef.current?.focus(), []);
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-6 space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">Search &amp; Discover</h1>
+        <p className="text-gray-500 dark:text-gray-400">
+          Find giveaways, help requests, and community members.
+        </p>
+      </header>
+
+      {/* Search input */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <Input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search posts and people..."
+          aria-label="Search"
+          className="pl-9"
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Tabs value={type} onValueChange={(value) => setType(value as SearchType)}>
+          <TabsList>
+            {SEARCH_TYPES.map((option) => (
+              <TabsTrigger key={option.value} value={option.value}>
+                {option.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+
+        <Select
+          value={category}
+          onValueChange={(value) =>
+            setCategory(value as PostCategory | "all")
+          }
+        >
+          <SelectTrigger className="w-[160px]">
+            <SlidersHorizontal className="h-4 w-4" />
+            <SelectValue placeholder="Category" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_CATEGORIES}>All categories</SelectItem>
+            {POST_CATEGORIES.map((cat) => (
+              <SelectItem key={cat} value={cat} className="capitalize">
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={sort} onValueChange={(value) => setSort(value as SearchSort)}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue placeholder="Sort" />
+          </SelectTrigger>
+          <SelectContent>
+            {SEARCH_SORTS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Button
+          type="button"
+          variant={activeOnly ? "default" : "outline"}
+          size="sm"
+          onClick={() => setActiveOnly((value) => !value)}
+        >
+          Active only
+        </Button>
+      </div>
+
+      {/* Results */}
+      <section className="space-y-4">
+        {isLoading && <SearchSkeleton />}
+
+        {error && !isLoading && (
+          <Card>
+            <CardContent className="p-6 text-center text-red-600 dark:text-red-400">
+              {error}
+            </CardContent>
+          </Card>
+        )}
+
+        {!isLoading && !error && posts.length > 0 && (
+          <>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {posts.length} {posts.length === 1 ? "result" : "results"}
+            </p>
+            {posts.map((post) => (
+              <PostCard key={post.id} post={post} />
+            ))}
+          </>
+        )}
+
+        {noResults && (
+          <Card>
+            <CardContent className="p-8 text-center space-y-2">
+              <Frown className="w-10 h-10 text-gray-400 mx-auto" />
+              <h3 className="text-lg font-semibold">No results found</h3>
+              <p className="text-gray-500 dark:text-gray-400">
+                We couldn&apos;t find anything matching your search. Try a
+                different keyword or clear your filters.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {idle && (
+          <Card>
+            <CardContent className="p-8 text-center space-y-2">
+              <Search className="w-10 h-10 text-gray-400 mx-auto" />
+              <h3 className="text-lg font-semibold">Start exploring</h3>
+              <p className="text-gray-500 dark:text-gray-400">
+                Search by keyword or pick a filter to discover giveaways and
+                help requests.
+              </p>
+              <Button variant="outline" size="sm" onClick={focusInput}>
+                Search now
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </section>
+
+      {/* People discovery */}
+      {visiblePeople.length > 0 && (
+        <section className="space-y-3">
+          <div className="flex items-center gap-2">
+            <Users className="h-5 w-5 text-gray-500" />
+            <h2 className="text-lg font-semibold">People to discover</h2>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {visiblePeople.map((person) => (
+              <PersonCard key={person.id} person={person} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<div className="max-w-3xl mx-auto px-4 py-6"><SearchSkeleton /></div>}>
+      <SearchView />
+    </Suspense>
+  );
+}

--- a/app/components/desktop-sidebar.tsx
+++ b/app/components/desktop-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Gift,
   Home,
   Plus,
+  Search,
   Settings,
   ShieldCheck,
   TrendingUp,
@@ -32,6 +33,7 @@ export function DesktopSidebar() {
 
   const navigation = [
     { name: 'Feed', href: '/feed', icon: Home },
+    { name: 'Search', href: '/search', icon: Search },
     { name: 'Activity', href: '/activity', icon: TrendingUp },
     { name: 'Leaderboard', href: '/leaderboard', icon: Trophy },
     ...(['admin', 'moderator'].includes(user?.role ?? '')

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, Moon, Settings, Sun, User, Wallet } from "lucide-react";
+import { LogOut, Moon, Search, Settings, Sun, User, Wallet } from "lucide-react";
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -24,24 +24,33 @@ export function Navbar() {
   const { user, logout, theme, toggleTheme } = useAppContext();
   const router = useRouter();
 
-  // ✅ Search state
+  // Quick-search state. The input is an entry point to the full /search page;
+  // it also shows a small live preview of matching posts as you type.
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState([]);
+  const [results, setResults] = useState<{ id: string; title: string }[]>([]);
 
   const handleLogout = () => {
     logout();
     router.push("/");
   };
 
-  // ✅ Debounce search
+  const goToSearch = () => {
+    const trimmed = query.trim();
+    router.push(trimmed ? `/search?q=${encodeURIComponent(trimmed)}` : "/search");
+    setResults([]);
+  };
+
+  // Debounced live preview of matching posts.
   useEffect(() => {
     const timeout = setTimeout(() => {
-      if (query) {
-        fetch(`/api/posts?q=${query}`)
+      const trimmed = query.trim();
+      if (trimmed) {
+        fetch(`/api/posts?q=${encodeURIComponent(trimmed)}&limit=5`)
           .then((res) => res.json())
           .then((data) => {
             setResults(data?.data?.posts || []);
-          });
+          })
+          .catch(() => setResults([]));
       } else {
         setResults([]);
       }
@@ -67,27 +76,46 @@ export function Navbar() {
             />
           </Link>
 
-          {/* ✅ Search Bar */}
+          {/* Search Bar */}
           <div className="relative hidden md:block">
-            <input
-              type="text"
-              placeholder="Search posts..."
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              className="px-3 py-1 border rounded-md w-64"
-            />
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                goToSearch();
+              }}
+              className="relative"
+            >
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <input
+                type="text"
+                placeholder="Search posts and people..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                aria-label="Search"
+                className="pl-9 pr-3 py-1.5 border border-gray-200 dark:border-gray-700 bg-transparent rounded-md w-72 focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </form>
 
-            {/* ✅ Search Results Dropdown */}
-            {query && results.length > 0 && (
-              <div className="absolute top-10 left-0 w-full bg-white dark:bg-gray-800 shadow-md rounded-md p-2 z-50">
-                {results.map((post: any) => (
-                  <div
+            {/* Live preview dropdown */}
+            {query.trim() && results.length > 0 && (
+              <div className="absolute top-11 left-0 w-full bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 shadow-lg rounded-md p-1 z-50">
+                {results.map((post) => (
+                  <Link
                     key={post.id}
-                    className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer rounded"
+                    href={`/post/${post.id}`}
+                    onClick={() => setResults([])}
+                    className="block p-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer rounded truncate"
                   >
                     {post.title}
-                  </div>
+                  </Link>
                 ))}
+                <button
+                  type="button"
+                  onClick={goToSearch}
+                  className="w-full text-left p-2 text-sm font-medium text-orange-600 dark:text-orange-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                >
+                  View all results
+                </button>
               </div>
             )}
           </div>

--- a/app/lib/pagination.ts
+++ b/app/lib/pagination.ts
@@ -1,0 +1,89 @@
+/**
+ * Pagination query-parameter parsing utilities.
+ *
+ * These endpoints historically read pagination params with `parseInt(...)` and
+ * guarded them with a `value < 1` check. Because `parseInt("abc")` returns `NaN`
+ * and `NaN < 1` evaluates to `false`, non-numeric values slipped past validation
+ * and reached Prisma's `skip`/`take`, which threw and surfaced as opaque HTTP 500s.
+ * There was also no upper bound on `limit`, allowing unbounded page sizes.
+ *
+ * These helpers parse with `Number(...)`, fall back to sane defaults for missing
+ * or non-numeric input, and clamp the result into a safe `[min, max]` range.
+ */
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_LIMIT = 10;
+export const MAX_LIMIT = 100;
+
+/**
+ * Parse a raw query value into an integer, falling back to `fallback` for
+ * missing/non-numeric input and clamping the result to `[min, max]`.
+ */
+export function clampInt(
+  raw: string | null | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (raw === null || raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  const value = Math.trunc(parsed);
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+export interface Pagination {
+  page: number;
+  limit: number;
+  skip: number;
+}
+
+export interface PaginationOptions {
+  defaultLimit?: number;
+  maxLimit?: number;
+}
+
+/**
+ * Parse page-based pagination (`page` + `limit`) and derive `skip`.
+ * `page` is clamped to `>= 1`; `limit` is clamped to `[1, maxLimit]`.
+ */
+export function parsePagination(
+  searchParams: URLSearchParams,
+  options: PaginationOptions = {},
+): Pagination {
+  const { defaultLimit = DEFAULT_LIMIT, maxLimit = MAX_LIMIT } = options;
+
+  const page = clampInt(searchParams.get("page"), DEFAULT_PAGE, 1, Number.MAX_SAFE_INTEGER);
+  const limit = clampInt(searchParams.get("limit"), defaultLimit, 1, maxLimit);
+
+  return { page, limit, skip: (page - 1) * limit };
+}
+
+export interface OffsetPagination {
+  limit: number;
+  skip: number;
+}
+
+/**
+ * Parse offset-based pagination (`limit` + `skip`).
+ * `limit` is clamped to `[1, maxLimit]`; `skip` is clamped to `>= 0`.
+ */
+export function parseOffsetPagination(
+  searchParams: URLSearchParams,
+  options: PaginationOptions = {},
+): OffsetPagination {
+  const { defaultLimit = DEFAULT_LIMIT, maxLimit = MAX_LIMIT } = options;
+
+  const limit = clampInt(searchParams.get("limit"), defaultLimit, 1, maxLimit);
+  const skip = clampInt(searchParams.get("skip"), 0, 0, Number.MAX_SAFE_INTEGER);
+
+  return { limit, skip };
+}

--- a/app/lib/search.ts
+++ b/app/lib/search.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure helpers for the global search & discovery surface.
+ *
+ * Kept free of React/DOM so the query-building and filtering logic can be
+ * unit-tested in isolation and reused by the search page and the navbar.
+ */
+
+export type SearchType = "all" | "giveaway" | "request";
+export type SearchSort = "recent" | "popular" | "ending_soon";
+
+export const SEARCH_TYPES: { value: SearchType; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "giveaway", label: "Giveaways" },
+  { value: "request", label: "Requests" },
+];
+
+export const SEARCH_SORTS: { value: SearchSort; label: string }[] = [
+  { value: "recent", label: "Most recent" },
+  { value: "popular", label: "Most popular" },
+  { value: "ending_soon", label: "Ending soon" },
+];
+
+/** Post categories, mirrored from the Prisma `PostCategory` enum. */
+export const POST_CATEGORIES = [
+  "electronics",
+  "clothing",
+  "books",
+  "furniture",
+  "toys",
+  "food",
+  "sports",
+  "beauty",
+  "automotive",
+  "other",
+] as const;
+
+export type PostCategory = (typeof POST_CATEGORIES)[number];
+
+export interface SearchFilters {
+  q?: string;
+  type?: SearchType;
+  category?: PostCategory | "all" | "";
+  sort?: SearchSort;
+  /** When true, restrict to posts whose deadline has not yet passed. */
+  activeOnly?: boolean;
+  page?: number;
+  limit?: number;
+}
+
+/**
+ * Build the query string for `GET /api/posts` from the current search filters.
+ *
+ * Empty/"all"/default values are omitted so the URL stays clean and the backend
+ * receives only meaningful parameters. `activeOnly` maps to the API's
+ * `filter=active`.
+ */
+export function buildPostsSearchQuery(filters: SearchFilters): string {
+  const params = new URLSearchParams();
+
+  const q = filters.q?.trim();
+  if (q) params.set("q", q);
+
+  if (filters.type && filters.type !== "all") {
+    params.set("type", filters.type);
+  }
+
+  if (filters.category && filters.category !== "all") {
+    params.set("category", filters.category);
+  }
+
+  // "recent" is the API default ordering, so only send non-default sorts.
+  if (filters.sort && filters.sort !== "recent") {
+    params.set("sort", filters.sort);
+  }
+
+  if (filters.activeOnly) {
+    params.set("filter", "active");
+  }
+
+  if (filters.page && filters.page > 1) {
+    params.set("page", String(filters.page));
+  }
+
+  if (filters.limit) {
+    params.set("limit", String(filters.limit));
+  }
+
+  return params.toString();
+}
+
+/** True when the user has not provided any keyword or narrowing filter yet. */
+export function hasActiveSearch(filters: SearchFilters): boolean {
+  return Boolean(
+    filters.q?.trim() ||
+      (filters.type && filters.type !== "all") ||
+      (filters.category && filters.category !== "all") ||
+      filters.activeOnly,
+  );
+}
+
+export interface DiscoveryPerson {
+  id: string;
+  name: string;
+  avatar_url?: string | null;
+  xp?: number;
+}
+
+/**
+ * Filter leaderboard people by a free-text query (case-insensitive name match).
+ * The leaderboard API has no `q` parameter, so people discovery is filtered
+ * client-side. An empty query returns everyone (capped by `limit`).
+ */
+export function filterPeople<T extends DiscoveryPerson>(
+  people: T[],
+  query: string | undefined,
+  limit = 12,
+): T[] {
+  const q = query?.trim().toLowerCase();
+  const matches = q
+    ? people.filter((person) => person.name?.toLowerCase().includes(q))
+    : people;
+  return matches.slice(0, limit);
+}

--- a/app/tests/api/entries.test.ts
+++ b/app/tests/api/entries.test.ts
@@ -723,7 +723,11 @@ describe('Entry API Endpoints', () => {
       });
     });
 
-    it('should reject invalid pagination parameters', async () => {
+    it('should clamp out-of-range pagination parameters to safe defaults', async () => {
+      prisma.post.findUnique = vi.fn().mockResolvedValue(post);
+      prisma.entry.findMany = vi.fn().mockResolvedValue([]);
+      prisma.entry.count = vi.fn().mockResolvedValue(0);
+
       const request = createMockRequest(
         `http://localhost:3000/api/posts/${post.id}/entries?page=0&limit=-1`,
       );
@@ -733,12 +737,17 @@ describe('Entry API Endpoints', () => {
       });
       const { status, data } = await parseResponse(response);
 
-      expect(status).toBe(400);
-      expect(data.success).toBe(false);
-      expect(data.error).toBe('Invalid pagination parameters');
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.pagination.page).toBe(1);
+      expect(data.data.pagination.limit).toBe(1);
     });
 
-    it('should reject limit greater than 100', async () => {
+    it('should clamp limit greater than 100 down to 100', async () => {
+      prisma.post.findUnique = vi.fn().mockResolvedValue(post);
+      prisma.entry.findMany = vi.fn().mockResolvedValue([]);
+      prisma.entry.count = vi.fn().mockResolvedValue(0);
+
       const request = createMockRequest(
         `http://localhost:3000/api/posts/${post.id}/entries?limit=101`,
       );
@@ -748,9 +757,29 @@ describe('Entry API Endpoints', () => {
       });
       const { status, data } = await parseResponse(response);
 
-      expect(status).toBe(400);
-      expect(data.success).toBe(false);
-      expect(data.error).toBe('Invalid pagination parameters');
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.pagination.limit).toBe(100);
+    });
+
+    it('should fall back to defaults for non-numeric pagination parameters', async () => {
+      prisma.post.findUnique = vi.fn().mockResolvedValue(post);
+      prisma.entry.findMany = vi.fn().mockResolvedValue([]);
+      prisma.entry.count = vi.fn().mockResolvedValue(0);
+
+      const request = createMockRequest(
+        `http://localhost:3000/api/posts/${post.id}/entries?page=abc&limit=xyz`,
+      );
+
+      const response = await GetEntries(request, {
+        params: Promise.resolve({ id: post.id }),
+      });
+      const { status, data } = await parseResponse(response);
+
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.pagination.page).toBe(1);
+      expect(data.data.pagination.limit).toBe(10);
     });
 
     it('should return 404 for non-existent post', async () => {

--- a/app/tests/api/posts.test.ts
+++ b/app/tests/api/posts.test.ts
@@ -194,6 +194,24 @@ describe("Posts API", () => {
       );
     });
 
+    it("should filter by category", async () => {
+      prisma.post.findMany = vi.fn().mockResolvedValue([]);
+      prisma.post.count = vi.fn().mockResolvedValue(0);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/posts?category=electronics",
+      );
+      const response = await GET(request);
+      const { status } = await parseResponse(response);
+
+      expect(status).toBe(200);
+      expect(prisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ category: "electronics" }),
+        }),
+      );
+    });
+
     it("should sort by ending_soon", async () => {
       prisma.post.findMany = vi.fn().mockResolvedValue([]);
       prisma.post.count = vi.fn().mockResolvedValue(0);

--- a/app/tests/api/posts.test.ts
+++ b/app/tests/api/posts.test.ts
@@ -103,6 +103,38 @@ describe("Posts API", () => {
       expect(data.data.limit).toBe(10);
     });
 
+    it("should not 500 on non-numeric pagination params and fall back to defaults", async () => {
+      prisma.post.findMany = vi.fn().mockResolvedValue([]);
+      prisma.post.count = vi.fn().mockResolvedValue(0);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/posts?page=abc&limit=-5",
+      );
+      const response = await GET(request);
+      const { status, data } = await parseResponse(response);
+
+      expect(status).toBe(200);
+      expect(data.data.page).toBe(1);
+      expect(data.data.limit).toBe(1);
+      expect(prisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 1 }),
+      );
+    });
+
+    it("should clamp an oversized limit to the maximum", async () => {
+      prisma.post.findMany = vi.fn().mockResolvedValue([]);
+      prisma.post.count = vi.fn().mockResolvedValue(0);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/posts?limit=100000",
+      );
+      const response = await GET(request);
+      const { status, data } = await parseResponse(response);
+
+      expect(status).toBe(200);
+      expect(data.data.limit).toBe(100);
+    });
+
     // ✅ NEW TEST: search query, type filter, sort
     it("should handle search query, type filter, and sort", async () => {
       const mockPosts = [

--- a/app/tests/lib/pagination.test.ts
+++ b/app/tests/lib/pagination.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampInt,
+  parseOffsetPagination,
+  parsePagination,
+} from "@/lib/pagination";
+
+const params = (query: string) => new URLSearchParams(query);
+
+describe("clampInt", () => {
+  it("returns the fallback for missing values", () => {
+    expect(clampInt(null, 5, 1, 100)).toBe(5);
+    expect(clampInt(undefined, 5, 1, 100)).toBe(5);
+    expect(clampInt("", 5, 1, 100)).toBe(5);
+    expect(clampInt("   ", 5, 1, 100)).toBe(5);
+  });
+
+  it("returns the fallback for non-numeric values (the NaN bug)", () => {
+    expect(clampInt("abc", 5, 1, 100)).toBe(5);
+    expect(clampInt("12abc", 5, 1, 100)).toBe(5);
+    expect(clampInt("NaN", 5, 1, 100)).toBe(5);
+    expect(clampInt("Infinity", 5, 1, 100)).toBe(5);
+  });
+
+  it("clamps numbers into the [min, max] range", () => {
+    expect(clampInt("-5", 5, 1, 100)).toBe(1);
+    expect(clampInt("0", 5, 1, 100)).toBe(1);
+    expect(clampInt("250", 5, 1, 100)).toBe(100);
+    expect(clampInt("42", 5, 1, 100)).toBe(42);
+  });
+
+  it("truncates fractional values", () => {
+    expect(clampInt("3.9", 5, 1, 100)).toBe(3);
+  });
+});
+
+describe("parsePagination", () => {
+  it("uses defaults when params are absent", () => {
+    expect(parsePagination(params(""))).toEqual({
+      page: 1,
+      limit: 10,
+      skip: 0,
+    });
+  });
+
+  it("derives skip from page and limit", () => {
+    expect(parsePagination(params("page=3&limit=20"))).toEqual({
+      page: 3,
+      limit: 20,
+      skip: 40,
+    });
+  });
+
+  it("does not 500 on non-numeric input — falls back to defaults", () => {
+    expect(parsePagination(params("page=abc&limit=xyz"))).toEqual({
+      page: 1,
+      limit: 10,
+      skip: 0,
+    });
+  });
+
+  it("clamps page<1 and limit out of range", () => {
+    expect(parsePagination(params("page=0&limit=-5"))).toEqual({
+      page: 1,
+      limit: 1,
+      skip: 0,
+    });
+    expect(parsePagination(params("limit=9999")).limit).toBe(100);
+  });
+
+  it("honors custom default and max limit", () => {
+    expect(parsePagination(params(""), { defaultLimit: 50 }).limit).toBe(50);
+    expect(
+      parsePagination(params("limit=40"), { maxLimit: 25 }).limit,
+    ).toBe(25);
+  });
+});
+
+describe("parseOffsetPagination", () => {
+  it("uses defaults when params are absent", () => {
+    expect(parseOffsetPagination(params(""), { defaultLimit: 20 })).toEqual({
+      limit: 20,
+      skip: 0,
+    });
+  });
+
+  it("clamps skip to >= 0 and falls back on non-numeric input", () => {
+    expect(parseOffsetPagination(params("skip=-3&limit=abc"), {
+      defaultLimit: 20,
+    })).toEqual({ limit: 20, skip: 0 });
+  });
+
+  it("clamps limit to the max", () => {
+    expect(
+      parseOffsetPagination(params("limit=500"), { defaultLimit: 20 }).limit,
+    ).toBe(100);
+  });
+});

--- a/app/tests/lib/search.test.ts
+++ b/app/tests/lib/search.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPostsSearchQuery,
+  filterPeople,
+  hasActiveSearch,
+} from "@/lib/search";
+
+const parse = (qs: string) => new URLSearchParams(qs);
+
+describe("buildPostsSearchQuery", () => {
+  it("returns an empty string for empty/default filters", () => {
+    expect(buildPostsSearchQuery({})).toBe("");
+    expect(buildPostsSearchQuery({ q: "", type: "all", sort: "recent" })).toBe(
+      "",
+    );
+  });
+
+  it("includes a trimmed keyword", () => {
+    expect(parse(buildPostsSearchQuery({ q: "  bike  " })).get("q")).toBe(
+      "bike",
+    );
+  });
+
+  it("omits the 'all' type but includes specific types", () => {
+    expect(parse(buildPostsSearchQuery({ type: "all" })).has("type")).toBe(
+      false,
+    );
+    expect(parse(buildPostsSearchQuery({ type: "giveaway" })).get("type")).toBe(
+      "giveaway",
+    );
+  });
+
+  it("omits the default 'recent' sort but includes other sorts", () => {
+    expect(parse(buildPostsSearchQuery({ sort: "recent" })).has("sort")).toBe(
+      false,
+    );
+    expect(parse(buildPostsSearchQuery({ sort: "popular" })).get("sort")).toBe(
+      "popular",
+    );
+  });
+
+  it("includes category unless it is 'all'", () => {
+    expect(
+      parse(buildPostsSearchQuery({ category: "all" })).has("category"),
+    ).toBe(false);
+    expect(
+      parse(buildPostsSearchQuery({ category: "electronics" })).get("category"),
+    ).toBe("electronics");
+  });
+
+  it("maps activeOnly to filter=active", () => {
+    expect(parse(buildPostsSearchQuery({ activeOnly: true })).get("filter")).toBe(
+      "active",
+    );
+    expect(
+      parse(buildPostsSearchQuery({ activeOnly: false })).has("filter"),
+    ).toBe(false);
+  });
+
+  it("only includes page when greater than 1", () => {
+    expect(parse(buildPostsSearchQuery({ page: 1 })).has("page")).toBe(false);
+    expect(parse(buildPostsSearchQuery({ page: 3 })).get("page")).toBe("3");
+  });
+
+  it("composes multiple filters", () => {
+    const params = parse(
+      buildPostsSearchQuery({
+        q: "laptop",
+        type: "giveaway",
+        category: "electronics",
+        sort: "popular",
+        activeOnly: true,
+        limit: 30,
+      }),
+    );
+    expect(params.get("q")).toBe("laptop");
+    expect(params.get("type")).toBe("giveaway");
+    expect(params.get("category")).toBe("electronics");
+    expect(params.get("sort")).toBe("popular");
+    expect(params.get("filter")).toBe("active");
+    expect(params.get("limit")).toBe("30");
+  });
+});
+
+describe("hasActiveSearch", () => {
+  it("is false with no keyword or narrowing filter", () => {
+    expect(hasActiveSearch({})).toBe(false);
+    expect(hasActiveSearch({ type: "all", category: "all", sort: "popular" })).toBe(
+      false,
+    );
+  });
+
+  it("is true when any meaningful filter is present", () => {
+    expect(hasActiveSearch({ q: "hi" })).toBe(true);
+    expect(hasActiveSearch({ type: "request" })).toBe(true);
+    expect(hasActiveSearch({ category: "books" })).toBe(true);
+    expect(hasActiveSearch({ activeOnly: true })).toBe(true);
+  });
+});
+
+describe("filterPeople", () => {
+  const people = [
+    { id: "1", name: "Ada Lovelace", xp: 100 },
+    { id: "2", name: "Alan Turing", xp: 90 },
+    { id: "3", name: "Grace Hopper", xp: 80 },
+  ];
+
+  it("returns everyone (capped) when query is empty", () => {
+    expect(filterPeople(people, "")).toHaveLength(3);
+    expect(filterPeople(people, undefined, 2)).toHaveLength(2);
+  });
+
+  it("matches names case-insensitively", () => {
+    expect(filterPeople(people, "ALA").map((p) => p.id)).toEqual(["2"]);
+    expect(filterPeople(people, "a").map((p) => p.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(filterPeople(people, "zzz")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Closes #358 — Non-numeric pagination query params produce 500s across list endpoints

List endpoints read `page`/`limit` with `parseInt(...)` guarded by a `value < 1`
check. Because `parseInt("abc")` returns `NaN` and `NaN < 1` is `false`,
non-numeric values slipped past validation and reached Prisma's `skip`/`take`,
throwing opaque HTTP 500s. There was also no upper bound on `limit`.

- Added `lib/pagination.ts` with `parsePagination` (page-based) and
  `parseOffsetPagination` (offset-based) helpers: parse with `Number(...)`,
  fall back to sane defaults for missing/non-numeric input, and clamp to a
  safe range (`page >= 1`, `limit` in `[1, MAX]`).
- Applied to the posts, entries, comments, followers, following, and
  leaderboard endpoints.
- Tests: helper unit tests plus endpoint tests asserting `?page=abc&limit=-5`
  and oversized limits return clamped 200s instead of 500s.

## Closes #396 — Build global search and discovery page

A dedicated `/search` surface for finding posts and people, backed by the
existing `/api/posts` and `/api/leaderboard` endpoints.

- New `app/search/page.tsx`: debounced keyword search synced to a shareable
  URL; type (all/giveaway/request), category, and sort filters plus an
  "active only" toggle; reuses `PostCard` for results and renders
  people-discovery cards from the leaderboard; explicit loading, idle, and
  no-results states.
- `lib/search.ts`: pure, unit-tested helpers for building the `/api/posts`
  query string and filtering people.
- `/api/posts` now supports a `category` filter param so the category control
  is functional.
- Navbar quick-search routes to `/search` (with a live post preview); added a
  Search link to the desktop sidebar.

## Testing

- `npm run test:ci` (vitest): 276 passed, 5 skipped.
