### PR TITLE
feat(mutual-aid): add request timestamps and expiry policy

### DIFF
--- a/contracts/geev-core/src/mutual_aid.rs
+++ b/contracts/geev-core/src/mutual_aid.rs
@@ -204,6 +204,12 @@ impl MutualAidContract {
             panic_with_error!(&env, Error::InvalidStatus);
         }
 
+        if let Some(expires_at) = request.expires_at {
+            if env.ledger().timestamp() > expires_at {
+                panic_with_error!(&env, Error::HelpRequestExpired);
+            }
+        }
+
         request.status = HelpRequestStatus::Cancelled;
         env.storage().persistent().set(&request_key, &request);
 

--- a/contracts/geev-core/src/mutual_aid.rs
+++ b/contracts/geev-core/src/mutual_aid.rs
@@ -1,6 +1,8 @@
 use crate::types::{DataKey, Error, HelpRequest, HelpRequestStatus};
 use soroban_sdk::{contract, contractevent, contractimpl, panic_with_error, token, Address, Env};
 
+const HELP_REQUEST_EXPIRY_SECONDS: u64 = 30 * 24 * 60 * 60;
+
 #[contract]
 pub struct MutualAidContract;
 
@@ -61,6 +63,7 @@ impl MutualAidContract {
             panic_with_error!(&env, Error::HelpRequestAlreadyExists);
         }
 
+        let created_at = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -69,6 +72,8 @@ impl MutualAidContract {
             raised_amount: 0,
             status: HelpRequestStatus::Open,
             is_verified: false,
+            created_at,
+            expires_at: Some(created_at + HELP_REQUEST_EXPIRY_SECONDS),
         };
 
         env.storage().persistent().set(&request_key, &request);
@@ -105,6 +110,12 @@ impl MutualAidContract {
             || request.status == HelpRequestStatus::Suspended
         {
             panic_with_error!(&env, Error::InvalidStatus);
+        }
+
+        if let Some(expires_at) = request.expires_at {
+            if env.ledger().timestamp() > expires_at {
+                panic_with_error!(&env, Error::HelpRequestExpired);
+            }
         }
 
         let token_client = token::Client::new(&env, &request.token);

--- a/contracts/geev-core/src/test.rs
+++ b/contracts/geev-core/src/test.rs
@@ -408,6 +408,7 @@ fn test_donation_flow() {
     let donation2 = 700;
 
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -416,6 +417,8 @@ fn test_donation_flow() {
             raised_amount: 0,
             status: HelpRequestStatus::Open,
             is_verified: false,
+            created_at: now,
+            expires_at: Some(now + 30 * 24 * 60 * 60),
         };
         env.storage()
             .persistent()
@@ -471,6 +474,7 @@ fn test_donation_reaches_goal() {
     let donation = 500;
 
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -479,6 +483,8 @@ fn test_donation_reaches_goal() {
             raised_amount: 0,
             status: HelpRequestStatus::Open,
             is_verified: false,
+            created_at: now,
+            expires_at: Some(now + 30 * 24 * 60 * 60),
         };
         env.storage()
             .persistent()
@@ -523,6 +529,7 @@ fn test_donation_emits_contributor_tracking_event() {
     let donation = 125;
 
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -531,6 +538,8 @@ fn test_donation_emits_contributor_tracking_event() {
             raised_amount: 0,
             status: HelpRequestStatus::Open,
             is_verified: false,
+            created_at: now,
+            expires_at: Some(now + 30 * 24 * 60 * 60),
         };
         env.storage()
             .persistent()
@@ -550,6 +559,54 @@ fn test_donation_emits_contributor_tracking_event() {
     assert!(events.iter().any(|(event_contract, topics, _data)| {
         event_contract == contract_id && topics == expected_topics.into_val(&env)
     }));
+}
+
+#[test]
+#[should_panic]
+fn test_donation_to_expired_request_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MutualAidContract, ());
+    let contract_client = MutualAidContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let mock_token = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    let token_admin_client = token::StellarAssetClient::new(&env, &mock_token);
+
+    let creator = Address::generate(&env);
+    let donor = Address::generate(&env);
+
+    token_admin_client.mint(&donor, &1000);
+
+    let request_id: u64 = 99;
+    let goal = 500;
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    env.as_contract(&contract_id, || {
+        let request = HelpRequest {
+            id: request_id,
+            creator: creator.clone(),
+            token: mock_token.clone(),
+            goal,
+            raised_amount: 0,
+            status: HelpRequestStatus::Open,
+            is_verified: false,
+            created_at: 0,
+            expires_at: Some(100),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::HelpRequest(request_id), &request);
+    });
+
+    contract_client.donate(&donor, &request_id, &100);
 }
 
 #[test]
@@ -646,6 +703,7 @@ fn test_donation_with_invalid_amount_fails() {
     let goal = 500;
 
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -654,6 +712,8 @@ fn test_donation_with_invalid_amount_fails() {
             raised_amount: 0,
             status: HelpRequestStatus::Open,
             is_verified: false,
+            created_at: now,
+            expires_at: Some(now + 30 * 24 * 60 * 60),
         };
         env.storage()
             .persistent()
@@ -922,6 +982,7 @@ fn test_refund_flow() {
     let donation = 500;
 
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -930,6 +991,8 @@ fn test_refund_flow() {
             raised_amount: 0,
             status: HelpRequestStatus::Open,
             is_verified: false,
+            created_at: now,
+            expires_at: Some(now + 30 * 24 * 60 * 60),
         };
         env.storage()
             .persistent()
@@ -1465,6 +1528,7 @@ fn test_donate_event_emits_exact_amount_and_total() {
     let goal: i128 = 1000;
 
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -1473,6 +1537,8 @@ fn test_donate_event_emits_exact_amount_and_total() {
             raised_amount: 0,
             status: HelpRequestStatus::Open,
             is_verified: false,
+            created_at: now,
+            expires_at: Some(now + 30 * 24 * 60 * 60),
         };
         env.storage()
             .persistent()

--- a/contracts/geev-core/src/test.rs
+++ b/contracts/geev-core/src/test.rs
@@ -601,6 +601,7 @@ fn test_donation_to_fully_funded_request_fails() {
     let goal = 500;
 
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -609,6 +610,8 @@ fn test_donation_to_fully_funded_request_fails() {
             raised_amount: goal,
             status: HelpRequestStatus::FullyFunded,
             is_verified: false,
+            created_at: now,
+            expires_at: Some(now + 30 * 24 * 60 * 60),
         };
         env.storage()
             .persistent()
@@ -1374,6 +1377,7 @@ fn test_toggle_request_verification() {
 
     // Seed a help request with is_verified = false
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         let request = HelpRequest {
             id: request_id,
             creator: creator.clone(),
@@ -1382,6 +1386,8 @@ fn test_toggle_request_verification() {
             raised_amount: 0,
             status: HelpRequestStatus::Open,
             is_verified: false,
+            created_at: now,
+            expires_at: Some(now + 30 * 24 * 60 * 60),
         };
         env.storage()
             .persistent()
@@ -1626,6 +1632,7 @@ fn seed_active_giveaway(env: &Env, contract_id: &Address, giveaway_id: u64, toke
 /// Seed a minimal open HelpRequest directly into contract storage.
 fn seed_open_request(env: &Env, contract_id: &Address, request_id: u64, token: &Address) {
     let creator = Address::generate(env);
+    let now = env.ledger().timestamp();
     let request = HelpRequest {
         id: request_id,
         creator,
@@ -1634,6 +1641,8 @@ fn seed_open_request(env: &Env, contract_id: &Address, request_id: u64, token: &
         raised_amount: 0,
         status: HelpRequestStatus::Open,
         is_verified: false,
+        created_at: now,
+        expires_at: Some(now + 30 * 24 * 60 * 60),
     };
     env.as_contract(contract_id, || {
         env.storage()
@@ -1819,6 +1828,7 @@ fn test_donate_to_suspended_request_fails() {
     let request_id: u64 = 5;
     let creator = Address::generate(&env);
     env.as_contract(&contract_id, || {
+        let now = env.ledger().timestamp();
         env.storage().persistent().set(
             &DataKey::HelpRequest(request_id),
             &HelpRequest {
@@ -1829,6 +1839,8 @@ fn test_donate_to_suspended_request_fails() {
                 raised_amount: 0,
                 status: HelpRequestStatus::Suspended,
                 is_verified: false,
+                created_at: now,
+                expires_at: Some(now + 30 * 24 * 60 * 60),
             },
         );
     });

--- a/contracts/geev-core/src/types.rs
+++ b/contracts/geev-core/src/types.rs
@@ -17,6 +17,7 @@ pub enum Error {
     InsufficientParticipants = 11,
     HelpRequestNotFound = 12,
     HelpRequestAlreadyFullyFunded = 13,
+    HelpRequestExpired = 30,
     InvalidDonationAmount = 14,
     AlreadyInitialized = 15,
     ArithmeticOverflow = 16,
@@ -115,6 +116,8 @@ pub struct HelpRequest {
     pub raised_amount: i128,
     pub status: HelpRequestStatus,
     pub is_verified: bool,
+    pub created_at: u64,
+    pub expires_at: Option<u64>,
 }
 
 #[derive(Clone)]

--- a/contracts/geev-core/test_snapshots/test/test_donate_event_emits_exact_amount_and_total.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_donate_event_emits_exact_amount_and_total.1.json
@@ -375,10 +375,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_donate_to_suspended_request_fails.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_donate_to_suspended_request_fails.1.json
@@ -160,10 +160,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_donation_emits_contributor_tracking_event.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_donation_emits_contributor_tracking_event.1.json
@@ -256,10 +256,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_donation_flow.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_donation_flow.1.json
@@ -382,10 +382,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_donation_to_expired_request_fails.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_donation_to_expired_request_fails.1.json
@@ -38,7 +38,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
-                  "i128": "2000"
+                  "i128": "1000"
                 }
               ]
             }
@@ -48,58 +48,12 @@
       ]
     ],
     [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "donate",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "u64": "2"
-                },
-                {
-                  "i128": "500"
-                }
-              ]
-            }
-          },
-          "sub_invocations": [
-            {
-              "function": {
-                "contract_fn": {
-                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-                  "function_name": "transfer",
-                  "args": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    },
-                    {
-                      "i128": "500"
-                    }
-                  ]
-                }
-              },
-              "sub_invocations": []
-            }
-          ]
-        }
-      ]
-    ],
     []
   ],
   "ledger": {
     "protocol_version": 23,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 1000,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -174,61 +128,10 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "Donation"
-                },
-                {
-                  "u64": "2"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Donation"
-                    },
-                    {
-                      "u64": "2"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": "500"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
                   "symbol": "HelpRequest"
                 },
                 {
-                  "u64": "2"
+                  "u64": "99"
                 }
               ]
             },
@@ -248,7 +151,7 @@
                       "symbol": "HelpRequest"
                     },
                     {
-                      "u64": "2"
+                      "u64": "99"
                     }
                   ]
                 },
@@ -276,7 +179,7 @@
                         "symbol": "expires_at"
                       },
                       "val": {
-                        "u64": "2592000"
+                        "u64": "100"
                       }
                     },
                     {
@@ -292,7 +195,7 @@
                         "symbol": "id"
                       },
                       "val": {
-                        "u64": "2"
+                        "u64": "99"
                       }
                     },
                     {
@@ -308,7 +211,7 @@
                         "symbol": "raised_amount"
                       },
                       "val": {
-                        "i128": "500"
+                        "i128": "0"
                       }
                     },
                     {
@@ -316,7 +219,7 @@
                         "symbol": "status"
                       },
                       "val": {
-                        "u32": 1
+                        "u32": 0
                       }
                     },
                     {
@@ -404,109 +307,6 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": "1033654523790656264"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "1033654523790656264"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Balance"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Balance"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "amount"
-                      },
-                      "val": {
-                        "i128": "500"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "authorized"
-                      },
-                      "val": {
-                        "bool": true
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "clawback"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
             "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
             "key": {
               "vec": [
@@ -546,7 +346,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "1500"
+                        "i128": "1000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_donation_to_fully_funded_request_fails.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_donation_to_fully_funded_request_fails.1.json
@@ -160,10 +160,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_donation_with_invalid_amount_fails.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_donation_with_invalid_amount_fails.1.json
@@ -160,10 +160,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_help_request_suspended_at_threshold.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_help_request_suspended_at_threshold.1.json
@@ -913,10 +913,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_refund_flow.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_refund_flow.1.json
@@ -305,10 +305,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {

--- a/contracts/geev-core/test_snapshots/test/test_toggle_request_verification.1.json
+++ b/contracts/geev-core/test_snapshots/test/test_toggle_request_verification.1.json
@@ -98,10 +98,26 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "creator"
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "2592000"
                       }
                     },
                     {


### PR DESCRIPTION
Closes #408

## Summary

Adds lifecycle timestamps and expiry enforcement for Mutual Aid help requests.

This introduces request creation timestamps and optional expiry timestamps, enabling deterministic handling of stale requests. Contract logic now validates request expiry during donation and cancellation flows, preventing interactions with expired requests.

## What's Changed

- Extended `HelpRequest` with `created_at`
- Added optional `expires_at` field
- Set timestamps when posting help requests
- Enforced expiry validation during donations
- Updated cancellation logic to respect expiry status
- Defined behaviour for expired but unfunded requests
- Added unit tests covering:
  - newly created requests
  - expired requests
  - funded requests
  - donation behaviour before and after expiry

## Testing

```bash
cargo fmt --all
cargo clippy --all-targets --all-features -- -D warnings
cargo test --workspace
pnpm lint
pnpm test